### PR TITLE
Merge ops (gefs.v12.1.2-nco) into develop branch

### DIFF
--- a/jobs/JGEFS_ATMOS_AVGSPR_GEMPAK_META
+++ b/jobs/JGEFS_ATMOS_AVGSPR_GEMPAK_META
@@ -67,7 +67,7 @@ export FIXgempak=${FIXgempak:-$GEMPAKgefs/fix}
 # Define COM directories
 ##############################################
 # gefs_avgspr_meta.sh overrides COMIN locally to work with datatype.tbl
-export COMIN=${COMOUT:-${COMROOT}/${NET}/${envir}/${RUN}.${PDY}/$cyc}
+export COMIN=${COMIN:-${COMROOT}/${NET}/${envir}/${RUN}.${PDY}/$cyc}
 export COMOUT=${COMOUT:-${COMROOT}/${NET}/${envir}/${RUN}.${PDY}/$cyc}
 
 #############################

--- a/jobs/JGEFS_ATMOS_PRDGEN
+++ b/jobs/JGEFS_ATMOS_PRDGEN
@@ -71,7 +71,7 @@ export PARMgefs=${PARMgefs:-$HOMEgefs/parm}
 ##############################################
 # Define COM directories
 ##############################################
-export COMIN=${COMOUT:-${COMROOT}/${NET}/${envir}/${RUN}.${PDY}/$cyc}
+export COMIN=${COMIN:-${COMROOT}/${NET}/${envir}/${RUN}.${PDY}/$cyc}
 export COMOUT=${COMOUT:-${COMROOT}/${NET}/${envir}/${RUN}.${PDY}/$cyc}
 export COMINgfs=${COMINgfs:-$(compath.py gfs/prod/gfs.${PDY})/$cyc/atmos}
 

--- a/scripts/exgefs_atmos_post_cleanup.sh
+++ b/scripts/exgefs_atmos_post_cleanup.sh
@@ -111,7 +111,7 @@ if ((nmissing > 0)); then
 		If this is the first run or first 00z run after machine switch, then you can safely ignore it.
 		Otherwise please double check if the model missing any file.
 	EOF
-	cat msg |mail.py  -s "Skip $cycle GEFS cleanup." ncep.list.spa-helpdesk@noaa.gov
+	cat msg |mail.py  -s "Skip $cycle GEFS cleanup." nco.spa@noaa.gov
 	exit
 else # (( nmissing > 0 ))
 	echo "$(date) sfcsig sflux cleanup begin"

--- a/versions/gefs.ver
+++ b/versions/gefs.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.1.1
+export gefs_ver=v12.1.2
 
 export EnvVars_ver=1.0.3
 export ips_ver=18.0.1.163

--- a/versions/gefs_wcoss_dell_p3.ver
+++ b/versions/gefs_wcoss_dell_p3.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.1.1
+export gefs_ver=v12.1.2
 
 export EnvVars_ver=1.0.3
 export ips_ver=18.0.1.163

--- a/versions/gefs_wcoss_dell_p35.ver
+++ b/versions/gefs_wcoss_dell_p35.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.1.1
+export gefs_ver=v12.1.2
 
 export EnvVars_ver=1.0.3
 export ips_ver=18.0.1.163


### PR DESCRIPTION
Please note that gefs.v12.1.1 doesn't change anything but add wave/gempak transfer list for SDB, gefs.v12.1.1/parm/transfer_gefs_00[06,12,18]z_wave_gempak_gempak_1[2,3].list. Therefore, I didn't create a tag for gefs.v12.1.1.