### PR TITLE
Change the walltime of chem_post/prdgen to 3h

### DIFF
--- a/ecf/chem/jgefs_chem_post.ecf
+++ b/ecf/chem/jgefs_chem_post.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=3:30:00
+#PBS -l walltime=3:00:00
 #PBS -l place=vscatter,select=1:ncpus=12:mem=92GB:mpiprocs=12
 #PBS -l debug=true
 

--- a/ecf/chem/jgefs_chem_prdgen.ecf
+++ b/ecf/chem/jgefs_chem_prdgen.ecf
@@ -3,7 +3,7 @@
 #PBS -S /bin/bash
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
-#PBS -l walltime=3:30:00
+#PBS -l walltime=3:00:00
 #PBS -l place=vscatter,select=1:ncpus=3:mpiprocs=3:mem=4608MB
 #PBS -l debug=true
 


### PR DESCRIPTION
to be consistent with chem_forecast

 On branch feature/ops_port2wcoss2
 Changes to be committed:
	modified:   ecf/chem/jgefs_chem_post.ecf
	modified:   ecf/chem/jgefs_chem_prdgen.ecf

Refs: #23