### PR TITLE
Change gefs_ver to v12.3.1

### DIFF
--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.3.0
+export gefs_ver=v12.3.1
 
 export gfs_ver=v16.2
 export cfs_ver=v2.3


### PR DESCRIPTION
 On branch hotfix/sync_nco_gefs_v12.3.1
	modified:   versions/run.ver

Refs: #68