### PR TITLE
Remove the "GO TO" Statement in gefs_ensstat program

### DIFF
--- a/sorc/gefs_ensstat.fd/isrchne.f90
+++ b/sorc/gefs_ensstat.fd/isrchne.f90
@@ -36,7 +36,7 @@
       IF(N.LE.0) RETURN
       IF(INCX.LT.0) J=1-(N-1)*INCX
       DO 100 I=1,N
-         IF(X(J).NE.TARGET) GO TO 200
+         IF(X(J).NE.TARGET) EXIT
          J=J+INCX
   100 CONTINUE
   200 ISRCHNE=I


### PR DESCRIPTION
  This PR is to solve the BugZilla issue: [#337](http://www2.spa.ncep.noaa.gov/bugzilla/show_bug.cgi?id=337) by removing the "GO TO" statement in gefs_ensstat program. 

 On branch feature/remove_goto_bugzilla_337
	modified:   sorc/gefs_ensstat.fd/isrchne.f90

Fixes #74