### PR TITLE
Update gefs_ver to sync with NCO's changes

### DIFF
--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.3.6
+export gefs_ver=v12.3.8
 
 export gfs_ver=v16.3
 export cfs_ver=v2.3


### PR DESCRIPTION
The gefs_ver variable in versions/run.ver has been updated from v12.3.6 to the current version v12.3.8. This change has been applied by NCO in operational GEFS, and also needs to be applied to the EMC ops branch. After this change has been merged into both the ops and develop branches, it will resolve issue #131. 