### PR TITLE
Update GEFS tag from global-workflow and fix directory 

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -15,7 +15,7 @@ if [[ ! -d global-workflow.fd ]] ; then
     rm -f ${logs_dir}/checkout-global-workflow.log
     git clone https://github.com/NOAA-EMC/global-workflow.git global-workflow.fd >>  ${logs_dir}/checkout-global-workflow.log 2>&1
     cd global-workflow.fd
-    git checkout gefs_v12.3.6
+    git checkout gefs_v12.3.8
     cd sorc
     ./checkout.sh
     ERR=$?

--- a/sorc/link_gefs.sh
+++ b/sorc/link_gefs.sh
@@ -30,10 +30,10 @@ pwd=$(pwd -P)
 #------------------------------
 if [ $machine = "hera" ]; then
     FIX_DIR="/scratch2/NCEPDEV/ensemble/noscrub/common/FIX/gefs/fix_nco_gefsv12.3"
-    FIX_DIR_FV3="/scratch1/NCEPDEV/global/glopara/fix_nco_gfsv16.3.0"
+    FIX_DIR_FV3="/scratch1/NCEPDEV/global/glopara/fix"
 elif [ $machine == "wcoss2" ]; then
     FIX_DIR="/lfs/h2/emc/ens/save/emc.ens/FIX/gefs/fix_nco_gefsv12.3"
-    FIX_DIR_FV3="/lfs/h2/emc/global/save/emc.global/FIX/fix_nco_gfsv16.3.0"
+    FIX_DIR_FV3="/lfs/h2/emc/global/save/emc.global/FIX/fix_nco_gfsv15"
 fi
 
 # Delete Fix folder and relink/recopy it

--- a/sorc/link_gefs.sh
+++ b/sorc/link_gefs.sh
@@ -30,10 +30,10 @@ pwd=$(pwd -P)
 #------------------------------
 if [ $machine = "hera" ]; then
     FIX_DIR="/scratch2/NCEPDEV/ensemble/noscrub/common/FIX/gefs/fix_nco_gefsv12.3"
-    FIX_DIR_FV3="/scratch1/NCEPDEV/global/glopara/fix"
+    FIX_DIR_FV3="/scratch1/NCEPDEV/global/glopara/fix_nco_gfsv16.3.0"
 elif [ $machine == "wcoss2" ]; then
     FIX_DIR="/lfs/h2/emc/ens/save/emc.ens/FIX/gefs/fix_nco_gefsv12.3"
-    FIX_DIR_FV3="/lfs/h2/emc/global/save/emc.global/FIX/fix_nco_gfsv15"
+    FIX_DIR_FV3="/lfs/h2/emc/global/save/emc.global/FIX/fix_nco_gfsv16.3.0"
 fi
 
 # Delete Fix folder and relink/recopy it


### PR DESCRIPTION
This draft PR intends to update the GEFS tag in global-workflow from v12.3.6. to v12.3.8. This new tag includes a bugfix in gsl-prep-chem (more details on this bugfix can be found in gsl-prep-chem [issue #9](https://github.com/NOAA-GSL/GSL-prep-chem/issues/9)). Furthermore, `FIX_DIR_FV3` in `.sorc/link_gefs.sh` is updated to a directory that contains the most recent CO2 files. This draft PR addresses GEFS issue #132. When the location of the new fix directory is confirmed, this draft PR will change into a normal PR. This draft PR should not be merged until the new fix directory is confirmed. When this PR is merged, it will resolve GEFS issue #132. 