### PR TITLE
Sync NCO's changes for gefs.v12.3.9 

### DIFF
--- a/ecf/init/atmos/jgefs_atmos_init_recenter.ecf
+++ b/ecf/init/atmos/jgefs_atmos_init_recenter.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=0:30:00
-#PBS -l place=vscatter,select=1:ncpus=6:mpiprocs=6:mem=12GB
+#PBS -l place=vscatter,select=1:ncpus=6:mpiprocs=6:mem=24GB
 #PBS -l debug=true
 
 set -x

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -40,8 +40,8 @@ export PATH=$PATH:.
 
 export MAIL_LIST="Bing.Fu@noaa.gov,Walter.Kolczynski@noaa.gov,Eric.Sinsky@noaa.gov,nco.spa@noaa.gov"
 
-#export MAILTO="arash.bigdeli@noaa.gov"
-#export MAIL_LIST="arash.bigdeli@noaa.gov"
+#export MAILTO="wei.wei@noaa.gov"
+#export MAIL_LIST="wei.wei@noaa.gov"
 #export COMPATH=/lfs/h1/ops/prod/com/gfs:/lfs/h1/ops/prod/com/cfs:/lfs/h1/ops/prod/com/nawips:/lfs/h1/ops/prod/com/ecmwf:/lfs/h1/ops/prod/com/nam:/lfs/h1/ops/prod/com/obsproc:/lfs/h1/ops/prod/com/ukmet
 #export DCOMROOT=/lfs/h1/ops/prod/dcom
 #export DBNLOG=YES


### PR DESCRIPTION
This PR serves to sync all of NCO's changes that were made since code delivery of gefs.v12.3.9. Details regarding NCO's changes are summarized in issue #140. After these changes are merged into NOAA-EMC/ops, a tag called "gefs.v12.3.9-nco" will be created and then ops will be merged into develop. These actions will resolve issue #140. 