### PR TITLE
Sync NCO's changes for gefs.v12.3.10

### DIFF
--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,11 +1,11 @@
-export gefs_ver=v12.3.9
+export gefs_ver=v12.3.10
 
 export gfs_ver=v16.3
 export cfs_ver=v2.3
 export ecmwf_ver=v2.1
 export nawips_ver=v0.0
 export nam_ver=v4.2
-export obsproc_ver=v1.1
+export obsproc_ver=v1.2
 export ukmet_ver=v2.2
 
 export envvar_ver=1.0


### PR DESCRIPTION
This PR intends to merge the following changes made my NCO to the ops branch. 

- The `gefs_ver` variable in `versions/run.ver` has been updated from `v12.3.9` to the current version `v12.3.10`. 
- The `obsproc_ver` variable in `versions/run.ver` has been updated from `v1.1` to `v1.2`. 

After this change has been merged into both the ops and develop branches, it will resolve issue https://github.com/NOAA-EMC/GEFS/issues/143.