### PR TITLE
Sync NCO's changes for gefs.v12.3.12

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -15,7 +15,7 @@ if [[ ! -d global-workflow.fd ]] ; then
     rm -f ${logs_dir}/checkout-global-workflow.log
     git clone https://github.com/NOAA-EMC/global-workflow.git global-workflow.fd >>  ${logs_dir}/checkout-global-workflow.log 2>&1
     cd global-workflow.fd
-    git checkout gefs_v12.3.9
+    git checkout gefs_v12.3.12
     cd sorc
     ./checkout.sh
     ERR=$?

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.3.10
+export gefs_ver=v12.3.12
 
 export gfs_ver=v16.3
 export cfs_ver=v2.3


### PR DESCRIPTION
The purpose of this PR is to sync all of NCO's changes made to gefs.v12.3.12, which involve the preservation of mtime when copying files in `exglobal_prep_chem.sh`. More details regarding NCO's changes are summarized in issue #147. After these changes are merged into NOAA-EMC/ops, a tag called "gefs.v12.3.12-nco" will be created and then ops will be merged into develop. These actions will resolve issue #147 .