### PR TITLE
Sync changes made by EMC and NCO for GEFS.v12.3.13

### DIFF
--- a/ecf/gempak/atmos/jgefs_atmos_gempak_meta.ecf
+++ b/ecf/gempak/atmos/jgefs_atmos_gempak_meta.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=1:00:00
-#PBS -l place=vscatter,select=1:ncpus=8:mpiprocs=8:mem=32GB
+#PBS -l place=vscatter,select=1:ncpus=8:mpiprocs=8:mem=60GB
 #PBS -l debug=true
 
 set -x

--- a/scripts/exgefs_chem_init.py
+++ b/scripts/exgefs_chem_init.py
@@ -195,7 +195,7 @@ def main() -> None:
 # Handle error for missing files due to possibility of dangling symlinks (ignore_dangling_symlinks doesn't work properly; Python Issue 38523)
 def safe_copytree(source: str, destination: str) -> None:
     try:
-        shutil.copytree(source, destination, ignore_dangling_symlinks=True)
+        shutil.copytree(source, destination, ignore_dangling_symlinks=True,copy_function=shutil.copy)
     except shutil.Error as err:
         # shutil.Error from copytree are tuples of src, dest, err
         tuples = [t for t in err.args[0]]

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -15,7 +15,7 @@ if [[ ! -d global-workflow.fd ]] ; then
     rm -f ${logs_dir}/checkout-global-workflow.log
     git clone https://github.com/NOAA-EMC/global-workflow.git global-workflow.fd >>  ${logs_dir}/checkout-global-workflow.log 2>&1
     cd global-workflow.fd
-    git checkout gefs_v12.3.12
+    git checkout gefs_v12.3.14
     cd sorc
     ./checkout.sh
     ERR=$?

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -15,7 +15,7 @@ if [[ ! -d global-workflow.fd ]] ; then
     rm -f ${logs_dir}/checkout-global-workflow.log
     git clone https://github.com/NOAA-EMC/global-workflow.git global-workflow.fd >>  ${logs_dir}/checkout-global-workflow.log 2>&1
     cd global-workflow.fd
-    git checkout gefs_v12.3.14
+    git checkout gefs_v12.3.13
     cd sorc
     ./checkout.sh
     ERR=$?

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -40,8 +40,8 @@ export PATH=$PATH:.
 
 export MAIL_LIST="Bing.Fu@noaa.gov,Walter.Kolczynski@noaa.gov,Eric.Sinsky@noaa.gov,nco.spa@noaa.gov"
 
-#export MAILTO="wei.wei@noaa.gov"
-#export MAIL_LIST="wei.wei@noaa.gov"
+#export MAILTO="ethan.collins@noaa.gov"
+#export MAIL_LIST="ethan.collins@noaa.gov"
 #export COMPATH=/lfs/h1/ops/prod/com/gfs:/lfs/h1/ops/prod/com/cfs:/lfs/h1/ops/prod/com/nawips:/lfs/h1/ops/prod/com/ecmwf:/lfs/h1/ops/prod/com/nam:/lfs/h1/ops/prod/com/obsproc:/lfs/h1/ops/prod/com/ukmet
 #export DCOMROOT=/lfs/h1/ops/prod/dcom
 #export DBNLOG=YES

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.3.12
+export gefs_ver=v12.3.14
 
 export gfs_ver=v16.3
 export cfs_ver=v2.3

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.3.14
+export gefs_ver=v12.3.13
 
 export gfs_ver=v16.3
 export cfs_ver=v2.3


### PR DESCRIPTION
The GEFSv12.3.13 was implemented into operations for the 18z cycle on Tuesday (March 11th, 2025). This PR syncs changes made by EMC and NCO for this GEFSv12 upgrade.  

The following changes were made by EMC and handed to NCO:
- Checkout `gefs_v12.3.13` global-workflow tag, which includes the Gulf name changes made in global-workflow and WW3
- Update `gefs_ver` to `v12.3.13` in `versions/run.ver`

After the code handoff, NCO made the following changes prior to implementation:
- Update `mem` to 60GB in `ecf/gempak/atmos/jgefs_atmos_gempak_meta.ecf`
- Address Bugzilla issue 1334 by removing mtime preservation for files copied in `scripts/exgefs_chem_init.py` so that mirror latency times are more accurate
- Update commented `MAILTO` and `MAIL_LIST` in `versions/run.ver`

This PR addresses issue #150 and Bugzilla issue 1334.
