### PR TITLE
Sync NCO's changes for GEFS.v12.3.13

### DIFF
--- a/ecf/gempak/atmos/jgefs_atmos_gempak_meta.ecf
+++ b/ecf/gempak/atmos/jgefs_atmos_gempak_meta.ecf
@@ -4,7 +4,7 @@
 #PBS -q %QUEUE%
 #PBS -A %PROJ%-%PROJENVIR%
 #PBS -l walltime=1:00:00
-#PBS -l place=vscatter,select=1:ncpus=8:mpiprocs=8:mem=32GB
+#PBS -l place=vscatter,select=1:ncpus=8:mpiprocs=8:mem=60GB
 #PBS -l debug=true
 
 set -x

--- a/scripts/exgefs_chem_init.py
+++ b/scripts/exgefs_chem_init.py
@@ -195,7 +195,7 @@ def main() -> None:
 # Handle error for missing files due to possibility of dangling symlinks (ignore_dangling_symlinks doesn't work properly; Python Issue 38523)
 def safe_copytree(source: str, destination: str) -> None:
     try:
-        shutil.copytree(source, destination, ignore_dangling_symlinks=True)
+        shutil.copytree(source, destination, ignore_dangling_symlinks=True,copy_function=shutil.copy)
     except shutil.Error as err:
         # shutil.Error from copytree are tuples of src, dest, err
         tuples = [t for t in err.args[0]]

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -40,8 +40,8 @@ export PATH=$PATH:.
 
 export MAIL_LIST="Bing.Fu@noaa.gov,Walter.Kolczynski@noaa.gov,Eric.Sinsky@noaa.gov,nco.spa@noaa.gov"
 
-#export MAILTO="wei.wei@noaa.gov"
-#export MAIL_LIST="wei.wei@noaa.gov"
+#export MAILTO="ethan.collins@noaa.gov"
+#export MAIL_LIST="ethan.collins@noaa.gov"
 #export COMPATH=/lfs/h1/ops/prod/com/gfs:/lfs/h1/ops/prod/com/cfs:/lfs/h1/ops/prod/com/nawips:/lfs/h1/ops/prod/com/ecmwf:/lfs/h1/ops/prod/com/nam:/lfs/h1/ops/prod/com/obsproc:/lfs/h1/ops/prod/com/ukmet
 #export DCOMROOT=/lfs/h1/ops/prod/dcom
 #export DBNLOG=YES


### PR DESCRIPTION
This PR brings NCO's changes for GEFS.v12.3.13 to develop: 

- Update mem to 60GB in ecf/gempak/atmos/jgefs_atmos_gempak_meta.ecf
- Address Bugzilla issue 1334 by removing mtime preservation for files copied in scripts/exgefs_chem_init.py so that mirror latency times are more accurate
- Update commented MAILTO and MAIL_LIST in versions/run.ver