### PR TITLE
Add ICEG and move VIS variables 

### DIFF
--- a/parm/gefs_pgrb2a_f00.parm
+++ b/parm/gefs_pgrb2a_f00.parm
@@ -78,4 +78,5 @@
 :VIS:surface:
 :VVEL:850 mb:
 :WEASD:surface:
+:ICEG:10 m above mean sea level:
 ;############################ do not leave a blank line at the end

--- a/parm/gefs_pgrb2a_f00.parm
+++ b/parm/gefs_pgrb2a_f00.parm
@@ -75,6 +75,7 @@
 :VGRD:700 mb:
 :VGRD:850 mb:
 :VGRD:925 mb:
+:VIS:surface:
 :VVEL:850 mb:
 :WEASD:surface:
 ;############################ do not leave a blank line at the end

--- a/parm/gefs_pgrb2a_f00.parm_0p25
+++ b/parm/gefs_pgrb2a_f00.parm_0p25
@@ -37,3 +37,4 @@
 :MSLET:mean sea level:
 :VIS:surface:
 :HGT:cloud ceiling:
+:ICEG:10 m above mean sea level:

--- a/parm/gefs_pgrb2a_fhh.parm
+++ b/parm/gefs_pgrb2a_fhh.parm
@@ -82,6 +82,7 @@
 :VGRD:700 mb:
 :VGRD:850 mb:
 :VGRD:925 mb:
+:VIS:surface:
 :VVEL:850 mb:
 :WEASD:surface:
 :ICEG:10 m above mean sea level:

--- a/parm/gefs_pgrb2a_fhh.parm
+++ b/parm/gefs_pgrb2a_fhh.parm
@@ -84,4 +84,5 @@
 :VGRD:925 mb:
 :VVEL:850 mb:
 :WEASD:surface:
+:ICEG:10 m above mean sea level:
 ;############################ do not leave a blank line at the end

--- a/parm/gefs_pgrb2a_fhh.parm_0p25
+++ b/parm/gefs_pgrb2a_fhh.parm_0p25
@@ -36,3 +36,4 @@
 :MSLET:mean sea level:
 :VIS:surface:
 :HGT:cloud ceiling:
+:ICEG:10 m above mean sea level:

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -15,7 +15,7 @@ if [[ ! -d global-workflow.fd ]] ; then
     rm -f ${logs_dir}/checkout-global-workflow.log
     git clone https://github.com/NOAA-EMC/global-workflow.git global-workflow.fd >>  ${logs_dir}/checkout-global-workflow.log 2>&1
     cd global-workflow.fd
-    git checkout gefs_v12.3.13
+    git checkout gefs_v12.3.14
     cd sorc
     ./checkout.sh
     ERR=$?

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.3.13
+export gefs_ver=v12.3.14
 
 export gfs_ver=v16.3
 export cfs_ver=v2.3

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -38,7 +38,7 @@ export cfp_ver=2.0.4
 export USE_CFP=YES
 export PATH=$PATH:.
 
-export MAIL_LIST="Bing.Fu@noaa.gov,Walter.Kolczynski@noaa.gov,Eric.Sinsky@noaa.gov,nco.spa@noaa.gov"
+export MAIL_LIST="Bing.Fu@noaa.gov,Eric.Sinsky@noaa.gov,nco.spa@noaa.gov"
 
 #export MAILTO="ethan.collins@noaa.gov"
 #export MAIL_LIST="ethan.collins@noaa.gov"


### PR DESCRIPTION
This PR adds ICEG to the products for a GEFSv12 upgrade. Also, the VIS variable is moved from the "b" group to the "a" group. 

This PR will remain in draft until a global-workflow tag `gefs_v12.3.14` is created. 

Addresses #156