### PR TITLE
Sync changes made by NCO for GEFS.v12.3.16

### DIFF
--- a/parm/transfer/transfer_gefs_00z_atmos_sfcsig_sfcsig_1.list
+++ b/parm/transfer/transfer_gefs_00z_atmos_sfcsig_sfcsig_1.list
@@ -1,0 +1,33 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+_COMROOT_/gefs/_SHORTVER_/gefs._PDY_/
++ /00/
++ /00/atmos/
++ /00/atmos/sfcsig/
++ /00/atmos/sfcsig/ge[cp]*atmf0[01234][05]*
++ /00/atmos/sfcsig/ge[cp]*sfcf0[01234][05]*
+- *
+B 1220000

--- a/parm/transfer/transfer_gefs_00z_atmos_sfcsig_sfcsig_2.list
+++ b/parm/transfer/transfer_gefs_00z_atmos_sfcsig_sfcsig_2.list
@@ -1,0 +1,34 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+_COMROOT_/gefs/_SHORTVER_/gefs._PDY_/
++ /00/
++ /00/atmos/
++ /00/atmos/sfcsig/
++ /00/atmos/sfcsig/ge[cp]*atmf0[01234][149]*
++ /00/atmos/sfcsig/ge[cp]*sfcf0[01234][149]*
++ /00/atmos/sfcsig/geavg*f000*
+- *
+B 1220000

--- a/parm/transfer/transfer_gefs_00z_atmos_sfcsig_sfcsig_3.list
+++ b/parm/transfer/transfer_gefs_00z_atmos_sfcsig_sfcsig_3.list
@@ -1,0 +1,33 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+_COMROOT_/gefs/_SHORTVER_/gefs._PDY_/
++ /00/
++ /00/atmos/
++ /00/atmos/sfcsig/
++ /00/atmos/sfcsig/ge[cp]*atmf0[01234][28]*
++ /00/atmos/sfcsig/ge[cp]*sfcf0[01234][28]*
+- *
+B 1220000

--- a/parm/transfer/transfer_gefs_00z_atmos_sfcsig_sfcsig_4.list
+++ b/parm/transfer/transfer_gefs_00z_atmos_sfcsig_sfcsig_4.list
@@ -1,0 +1,33 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+_COMROOT_/gefs/_SHORTVER_/gefs._PDY_/
++ /00/
++ /00/atmos/
++ /00/atmos/sfcsig/
++ /00/atmos/sfcsig/ge[cp]*atmf0[01234][367]*
++ /00/atmos/sfcsig/ge[cp]*sfcf0[01234][367]*
+- *
+B 1220000

--- a/parm/transfer/transfer_gefs_12z_atmos_sfcsig_sfcsig_1.list
+++ b/parm/transfer/transfer_gefs_12z_atmos_sfcsig_sfcsig_1.list
@@ -1,0 +1,33 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+_COMROOT_/gefs/_SHORTVER_/gefs._PDY_/
++ /12/
++ /12/atmos/
++ /12/atmos/sfcsig/
++ /12/atmos/sfcsig/ge[cp]*atmf0[01234][05]*
++ /12/atmos/sfcsig/ge[cp]*sfcf0[01234][05]*
+- *
+B 1220000

--- a/parm/transfer/transfer_gefs_12z_atmos_sfcsig_sfcsig_2.list
+++ b/parm/transfer/transfer_gefs_12z_atmos_sfcsig_sfcsig_2.list
@@ -1,0 +1,34 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+_COMROOT_/gefs/_SHORTVER_/gefs._PDY_/
++ /12/
++ /12/atmos/
++ /12/atmos/sfcsig/
++ /12/atmos/sfcsig/ge[cp]*atmf0[01234][149]*
++ /12/atmos/sfcsig/ge[cp]*sfcf0[01234][149]*
++ /12/atmos/sfcsig/geavg*f000*
+- *
+B 1220000

--- a/parm/transfer/transfer_gefs_12z_atmos_sfcsig_sfcsig_3.list
+++ b/parm/transfer/transfer_gefs_12z_atmos_sfcsig_sfcsig_3.list
@@ -1,0 +1,33 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+_COMROOT_/gefs/_SHORTVER_/gefs._PDY_/
++ /12/
++ /12/atmos/
++ /12/atmos/sfcsig/
++ /12/atmos/sfcsig/ge[cp]*atmf0[01234][28]*
++ /12/atmos/sfcsig/ge[cp]*sfcf0[01234][28]*
+- *
+B 1220000

--- a/parm/transfer/transfer_gefs_12z_atmos_sfcsig_sfcsig_4.list
+++ b/parm/transfer/transfer_gefs_12z_atmos_sfcsig_sfcsig_4.list
@@ -1,0 +1,33 @@
+# This file specifies the directories to be transfered and, optionally, the files within
+# those directories to include or exclude.  If one directory is specified per line, it
+# will be used as both the source and destination.  If two directories are specified per
+# line, separated by one or more spaces, the first will be used as the source and the
+# second the destination.  Directories that begin with "com/" will be resolved using
+# the compath.py utility.  Rules may be placed below each directory or directory pair
+# and must begin with one of the following characters:
+#  -  exclude, specifies an exclude pattern
+#  +  include, specifies an include pattern
+#  .  merge, specifies a merge-file to read for more rules
+#  :  dir-merge, specifies a per-directory merge-file
+#  H  hide, specifies a pattern for hiding files from the transfer
+#  S  show, files that match the pattern are not hidden
+#  P  protect, specifies a pattern for protecting files from deletion
+#  R  risk, files that match the pattern are not protected
+#  !  clear, clears the current include/exclude list (takes no arg)
+#  B  bytes, relative size of the path in relation to the other paths in the list
+#  D  delete, delete extraneous files from destination directories (takes no arg)
+#  E  encrypt, enables data encryption [two cores should be allocated] (takes no arg)
+#  T  two-way syncronization will update both sides with latest changes (takes no arg)
+#  Z  compress data as it is sent, accepts optional compression level argument (1-9)
+# Rules higher in the list take precedence over lower ones.  By default, all files in a
+# directory are included, so if no exclude patterns match that file, it will be
+# transferred.
+
+_COMROOT_/gefs/_SHORTVER_/gefs._PDY_/
++ /12/
++ /12/atmos/
++ /12/atmos/sfcsig/
++ /12/atmos/sfcsig/ge[cp]*atmf0[01234][367]*
++ /12/atmos/sfcsig/ge[cp]*sfcf0[01234][367]*
+- *
+B 1220000


### PR DESCRIPTION
This PR syncs NCO's changes to the ops branch. The following changes were made by NCO:

-   Add 8 files in parm/transfer that allow mirroring of the sfcsig atm/sfc data files

Refs #161 