### PR TITLE
Sync changes made by NCO for GEFS.v12.3.17

### DIFF
--- a/gempak/ush/gefs_meta_850.sh_comb
+++ b/gempak/ush/gefs_meta_850.sh_comb
@@ -110,18 +110,6 @@ for area in us sam; do
 				ln -s ${COMINecmwf}.${ECM_PDY}/gempak/ecmwf_hr_${ECM_PDY}${ECM_cyc}f${fcsthr} ${fn}
 			fi
 
-			fn=ukmet
-			rm -rf ${fn}
-			if [ -r ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
-				ln -s ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
-			fi
-
-			fn=dgex
-			rm -rf ${fn}
-			if [ -r $COMINnawips/dgex.${PDY}/dgex_${PDY}${cyc}f${fcsthr} ]; then
-				ln -s $COMINnawips/dgex.${PDY}/dgex_${PDY}${cyc}f${fcsthr} ${fn}
-			fi
-
 			cat > cmdfile850  <<- EOF
 				DEVICE  = ${device}
 				PANEL   = 0
@@ -265,28 +253,6 @@ for area in us sam; do
 				#let color_number=$color_number+1
 			done
 
-			# ----- ukmet -----
-			gdfn=ukmet # gd file name
-			if [ -e ${gdfn} ]; then
-				cat >> cmdfile850 <<- EOF
-					GDFILE  = ${gdfn}
-					LINE    = 7/2/2/0
-					GDATTIM = F${fcsthr_ecm}
-					TITLE   = 7/-5/~ ? ${gdfn} ${ECM_cyc}Z (DASHED)|~${name}
-					run
-
-					EOF
-				if [ $WrottenZERO -eq 0 ]; then            
-					cat >> cmdfile850  <<- EOF
-						MAP     = 0
-						LATLON  = 0
-						CLEAR   = no
-
-						EOF
-				fi
-				WrottenZERO=1
-			fi
-			
 			# ----- ecmwf -----
 			gdfn=ecmwf # gd file name
 			if [ -e ${gdfn} ]; then
@@ -353,20 +319,6 @@ for area in us sam; do
 						EOF
 				fi
 				WrottenZERO=1
-			fi
-
-			# ----- dgex -----
-			gdfn=dgex # gd file name
-			if [ -e ${gdfn} ]; then
-				cat >> cmdfile850  <<- EOF
-					GDFILE  = ${gdfn} 
-					LINE    = 13/2/2/0
-					GDATTIM = F${fcsthr}
-					TITLE   = 13/-8/~ ? ${cyc}Z DGEX|~${name}
-					run
-
-					EOF
-
 			fi
 
 			cat cmdfile850

--- a/gempak/ush/gefs_meta_carib_spag.sh_comb
+++ b/gempak/ush/gefs_meta_carib_spag.sh_comb
@@ -117,18 +117,6 @@ for pres in 200 250 300; do
 				ln -s ${COMINecmwf}.${ECM_PDY}/gempak/ecmwf_hr_${ECM_PDY}${ECM_cyc}f${fcsthr} ${fn}
 			fi
 
-			fn=ukmet
-			rm -rf ${fn}
-			if [ -r ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
-				ln -s ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
-			fi
-
-			fn=dgex
-			rm -rf ${fn}
-			if [ -r $COMINnawips/dgex.${PDY}/dgex_${PDY}${cyc}f${fcsthr} ]; then
-				ln -s $COMINnawips/dgex.${PDY}/dgex_${PDY}${cyc}f${fcsthr} ${fn}
-			fi
-
 
 			cat > cmdfilecarib  <<- EOF
 				GDATTIM	= F${fcsthr}
@@ -276,30 +264,6 @@ for pres in 200 250 300; do
 				#let color_number=$color_number+1
 			done    # For grids loop
 
-			# ----- ukmet -----
-			gdfn=ukmet
-			if [ -e ${gdfn} ]; then
-				cat >> cmdfilecarib  <<- EOF
-					GDFILE  = ${gdfn}
-					LINE    = 7/2/2/0
-					GDATTIM = F${fcsthr_ecm}
-					TITLE   = 7/-4/~ ? UKMET ${ECM_cyc}Z (DASHED)|~${name} ${level} DM
-					run
-
-					EOF
-
-				if [ $WrottenZERO -eq 0 ]; then            
-					cat >> cmdfilecarib  <<- EOF
-						MAP     = 0
-						LATLON  = 0
-						CLEAR   = no
-
-						EOF
-					
-				fi
-				WrottenZERO=1
-			fi
-
 			# ----- ecmwf -----
 			gdfn=ecmwf
 			if [ -e ${gdfn} ]; then
@@ -370,20 +334,6 @@ for pres in 200 250 300; do
 					
 				fi
 				WrottenZERO=1
-			fi
-
-			# ----- dgex -----
-			gdfn=dgex
-			if [ -e ${gdfn} ]; then
-				cat >> cmdfilecarib  <<- EOF
-					GDFILE  = dgex 
-					LINE    = 13/2/2/0
-					GDATTIM = F${fcsthr}
-					TITLE   = 13/-7/~ ? ${cyc}Z DGEX|~${name} ${level} DM
-					run
-
-					EOF
-
 			fi
 
 			cat cmdfilecarib

--- a/gempak/ush/gefs_meta_hi_spag.sh_comb
+++ b/gempak/ush/gefs_meta_hi_spag.sh_comb
@@ -102,30 +102,6 @@ for level in ${levels}; do
 			ln -s ${COMINecmwf}.${ECM_PDY}/gempak/ecmwf_hr_${ECM_PDY}${ECM_cyc}f${fcsthr} ${fn}
 		fi
 
-		fn=ukmet
-		rm -rf ${fn}
-		if [ -r ${COMINukmet}.${ECM_PDY}/gempak/ukmet_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
-			ln -s ${COMINukmet}.${ECM_PDY}/gempak/ukmet_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
-		fi
-
-		#fn=cmc
-		#rm -rf ${fn}
-		#if [ -r $COMINnawips/cmc.${PDY}/cmc${PDY}${CMC_cyc}f${fcsthr_cmc} ]; then
-		#    ln -s $COMINnawips/cmc.${PDY}/cmc${PDY}${CMC_cyc}f${fcsthr_cmc} ${fn}
-		#fi
-
-		#fn=nogaps
-		#rm -rf ${fn}
-		#if [ -r $COMINnawips/nogaps.${PDY}/nogaps${PDY}${CMC_cyc}f${fcsthr_cmc} ]; then
-		#    ln -s $COMINnawips/nogaps.${PDY}/nogaps${PDY}${CMC_cyc}f${fcsthr_cmc} ${fn}
-		#fi
-
-		fn=dgex
-		rm -rf ${fn}
-		if [ -r $COMINnawips/dgex.${PDY}/dgex_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINnawips/dgex.${PDY}/dgex_${PDY}${cyc}f${fcsthr} ${fn}
-		fi
-
 		cat > cmdfilehi <<- EOF
 			GDATTIM	= F${fcsthr}
 			DEVICE	= ${device}
@@ -267,30 +243,6 @@ for level in ${levels}; do
 			#let color_number=$color_number+1
 		done
 
-		# ----- ukmet -----
-		gdfn=ukmet 
-		if [ -e ${gdfn} ]; then
-			cat >> cmdfilehi <<- EOF
-				GDFILE  = ${gdfn}
-				LINE    = 7/2/2/0
-				GDATTIM = F${fcsthr_ecm}
-				TITLE   = 7/-4/~ ? UKMET ${ECM_cyc}Z (DASHED)|~${name} ${level} DM
-				run
-
-				EOF
-			
-			if [ $WrottenZERO -eq 0 ]; then            
-				cat >> cmdfilehi <<- EOF
-					MAP     = 0
-					LATLON  = 0
-					CLEAR   = no
-
-					EOF
-				
-			fi
-			WrottenZERO=1
-		fi
-
 		# ----- ecmwf -----
 		gdfn=ecmwf 
 		if [ -e ${gdfn} ]; then
@@ -361,19 +313,6 @@ for level in ${levels}; do
 				
 			fi
 			WrottenZERO=1
-		fi
-
-		# ----- dgex -----
-		gdfn=dgex 
-		if [ -e ${gdfn} ]; then
-			cat >> cmdfilehi <<- EOF
-				GDFILE  = ${gdfn} 
-				LINE    = 13/2/2/0
-				GDATTIM = F${fcsthr}
-				TITLE   = 13/-7/~ ? ${cyc}Z DGEX|~${name} ${level} DM
-				run
-
-				EOF
 		fi
 
 		cat cmdfilehi

--- a/gempak/ush/gefs_meta_lows.sh_comb
+++ b/gempak/ush/gefs_meta_lows.sh_comb
@@ -83,7 +83,7 @@ for area in nam us trop sam hi; do
 		fcsthr_6=$( printf %03i $(( 10#${fcsthr} + 6 )) )
 		fcsthr_ecm=$( printf %03i $(( 10#${fcsthr} + $ECM_fcsthrs )) )
 		
-		rm -rf gefs_avg gefs_avg_6 gfs gfs_6 ecmwf ukmet dgex
+		rm -rf gefs_avg gefs_avg_6 gfs gfs_6 ecmwf
 
 		grids=${memberlist}
 		for fn in $(echo $grids)
@@ -127,18 +127,6 @@ for area in nam us trop sam hi; do
 		rm -rf ${fn}
 		if [ -r ${COMINecmwf}.${ECM_PDY}/gempak/ecmwf_hr_${ECM_PDY}${ECM_cyc}f${fcsthr} ]; then
 			ln -s ${COMINecmwf}.${ECM_PDY}/gempak/ecmwf_hr_${ECM_PDY}${ECM_cyc}f${fcsthr} ${fn}
-		fi
-
-		fn=ukmet
-		rm -rf ${fn}
-		if [ -r ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
-			ln -s ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
-		fi
-
-		fn=dgex
-		rm -rf ${fn}
-		if [ -r $COMINnawips/dgex.${PDY}/dgex_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINnawips/dgex.${PDY}/dgex_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 
@@ -287,29 +275,6 @@ for area in nam us trop sam hi; do
 			#let color_number=$color_number+1
 		done
 
-		# ----- ukmet -----
-		gdfn=ukmet # gd file name
-		if [ -e ${gdfn} ]; then
-			cat >> cmdfilelows  <<- EOF
-				GDFILE  = ${gdfn}
-				GDATTIM = F${fcsthr_ecm}
-				HILO    = 7/L${num}/900-1016/5/50/y
-				TITLE   = 7/-5/~ ? UKMET ${ECM_cyc}Z|~${name}
-				run
-
-				EOF
-
-			if [ $WrottenZERO -eq 0 ]; then            
-				cat >> cmdfilelows  <<- EOF
-					MAP     = 0
-					LATLON  = 0
-					CLEAR   = no
-
-					EOF
-			fi
-			WrottenZERO=1
-		fi 
-
 		# ----- ecmwf -----
 		gdfn=ecmwf # gd file name
 		if [ -e ${gdfn} ]; then
@@ -378,19 +343,6 @@ for area in nam us trop sam hi; do
 			fi
 			WrottenZERO=1
 		fi 
-
-		# ----- dgex -----
-		gdfn=dgex # gd file name
-		if [ -e ${gdfn} ]; then
-			cat >> cmdfilelows  <<- EOF
-				GDFILE  = ${gdfn} 
-				GDATTIM = F${fcsthr}
-				HILO    = 13/L${num}/900-1016/5/50/y
-				TITLE   = 13/-8/~ ? ${cyc}Z DGEX|~${name}
-				run
-
-				EOF
-		fi
 
 		cat cmdfilelows
 		gdplot2_nc < cmdfilelows

--- a/gempak/ush/gefs_meta_mar_00Z.sh
+++ b/gempak/ush/gefs_meta_mar_00Z.sh
@@ -46,8 +46,6 @@ gfscyc="12"
 gfscyc2="06"
 ecmwfcyc="12"
 ecmwfdate="${yesterday}"
-ukmetcyc="12"
-ukmetdate="${yesterday}"
 
 fcsthrs="000 012 024 036 048 060 072 084 096 108 120"
 levels="528 534 540 546 552 564 576"
@@ -88,13 +86,6 @@ for metaarea in pac atl; do
 			if [ -r $COMINecmwf.${ecmwfdate}/gempak/ecmwf_hr_${ecmwfdate}${ecmwfcyc}f${fcsthr} ]; then
 				ln -s $COMINecmwf.${ecmwfdate}/gempak/ecmwf_hr_${ecmwfdate}${ecmwfcyc}f${fcsthr} ${fn}
 			fi
-
-			fn=ukmet
-			rm -rf ${fn}
-			if [ -r ${COMINukmet}.${PDY}/gempak/ukmet_hr_${PDY}${cyc}f${fcsthr} ]; then
-				ln -s ${COMINukmet}.${PDY}/gempak/ukmet_hr_${PDY}${cyc}f${fcsthr} ${fn}
-			fi
-
 
 			export pgm=gdplot2_nc;. prep_step; startmsg
 
@@ -221,19 +212,6 @@ for metaarea in pac atl; do
 				WrottenZERO=1
 			fi
 
-			# ----- ukmet -----
-			gdfn=ukmet
-			if [ -e ${gdfn} ]; then
-				cat >> cmdfilemar  <<- EOF
-					GDFILE  = ${gdfn}
-					LINE    = 7/2/3/0
-					GDATTIM = F${fcsthr}
-					TITLE   = 7/-6/~ ? UKMET 00Z (DASHED)|~${metaarea} ${level} DM
-					run
-
-					EOF
-			fi
-
 			cat cmdfilemar
 			gdplot2_nc < cmdfilemar
 			err=$?
@@ -274,12 +252,6 @@ for metaarea in pac atl; do
 		rm -rf ${fn}
 		if [ -r $COMINecmwf.${ecmwfdate}/gempak/ecmwf_hr_${ecmwfdate}${ecmwfcyc}f${fcsthr} ]; then
 			ln -s $COMINecmwf.${ecmwfdate}/gempak/ecmwf_hr_${ecmwfdate}${ecmwfcyc}f${fcsthr} ${fn}
-		fi
-
-		fn=ukmet
-		rm -rf ${fn}
-		if [ -r $COMINukmet.${PDY}/gempak/ukmet_hr_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINukmet.${PDY}/gempak/ukmet_hr_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		export pgm=gdplot2_nc;. prep_step; startmsg
@@ -405,19 +377,6 @@ for metaarea in pac atl; do
 			WrottenZERO=1
 		fi
 
-		# ----- ukmet -----
-		gdfn=ukmet
-		if [ -e ${gdfn} ]; then
-			cat >> cmdfilemar_low  <<- EOF
-				GDFILE  = ${gdfn}
-				HILO    = 26/L${num}/900-1016/5/50/y
-				TITLE   = 26/-6/~ ? ${gdfn} 00Z|~${metaarea} ${metashname}
-				GDATTIM = F${fcsthr}
-				run
-
-				EOF
-
-		fi
 
 		cat cmdfilemar_low
 		gdplot2_nc < cmdfilemar_low

--- a/gempak/ush/gefs_meta_nam_spag.sh_comb
+++ b/gempak/ush/gefs_meta_nam_spag.sh_comb
@@ -124,17 +124,6 @@ for level in ${levels}; do
 			ln -s $COMINecmwf.${ECM_PDY}/gempak/ecmwf_hr_${ECM_PDY}${ECM_cyc}f${fcsthr} ${fn}
 		fi
 
-		fn=ukmet
-		rm -rf ${fn}
-		if [ -r ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
-			ln -s ${COMINukmet}.${ECM_PDY}/gempak/ukmet_hr_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
-		fi
-
-		fn=dgex
-		rm -rf ${fn}
-		if [ -r $COMINnawips/dgex.${PDY}/dgex_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINnawips/dgex.${PDY}/dgex_${PDY}${cyc}f${fcsthr} ${fn}
-		fi
 
 		cat > cmdfilenam  <<- EOF
 			GDATTIM	= F${fcsthr}
@@ -280,28 +269,6 @@ for level in ${levels}; do
 			#let color_number=$color_number+1
 		done
 
-		# ----- ukmet -----
-		gdfn=ukmet 
-		if [ -e ${gdfn} ]; then
-			cat >> cmdfilenam  <<- EOF
-				GDFILE  = ${gdfn}
-				LINE    = 7/2/2/0
-				GDATTIM = F${fcsthr_ecm}
-				TITLE   = 7/-4/~ ? UKMET ${ECM_cyc}Z (DASHED)|~${name} ${level} DM
-				run
-
-				EOF
-
-			if [ $WrottenZERO -eq 0 ]; then            
-				cat >> cmdfilenam  <<- EOF
-					MAP     = 0
-					LATLON  = 0
-					CLEAR   = no
-
-					EOF
-			fi
-			WrottenZERO=1
-		fi
 
 		# ----- ecmwf -----
 		gdfn=ecmwf 
@@ -367,19 +334,6 @@ for level in ${levels}; do
 					EOF
 			fi
 			WrottenZERO=1
-		fi
-
-		# ----- dgex -----
-		gdfn=dgex 
-		if [ -e ${gdfn} ]; then
-			cat >> cmdfilenam  <<- EOF
-				GDFILE  = ${gdfn} 
-				LINE    = 13/2/2/0
-				GDATTIM = F${fcsthr}
-				TITLE   = 13/-7/~ ? ${cyc}Z DGEX|~${name} ${level} DM
-				run
-
-				EOF
 		fi
 
 		cat cmdfilenam

--- a/gempak/ush/gefs_meta_sam_spag.sh_comb
+++ b/gempak/ush/gefs_meta_sam_spag.sh_comb
@@ -127,18 +127,6 @@ for level in ${levels}; do
 			 ln -s $COMINecmwf.${ECM_PDY}/gempak/ecmwf_hr_${ECM_PDY}${ECM_cyc}f${fcsthr} ${fn}
 		fi
 
-		fn=ukmet
-		rm -rf ${fn}
-		if [ -r ${COMINukmet}.${ECM_PDY}/gempak/ukmet_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ]; then
-			 ln -s ${COMINukmet}.${ECM_PDY}/gempak/ukmet_${ECM_PDY}${ECM_cyc}f${fcsthr_ecm} ${fn}
-		fi
-
-		fn=dgex
-		rm -rf ${fn}
-		if [ -r $COMINnawips/dgex.${PDY}/dgex_${PDY}${cyc}f${fcsthr} ]; then
-			 ln -s $COMINnawips/dgex.${PDY}/dgex_${PDY}${cyc}f${fcsthr} ${fn}
-		fi
-
 		cat > cmdfilesam  <<- EOF
 			GDATTIM	= F${fcsthr}
 			DEVICE	= ${device}
@@ -279,27 +267,6 @@ for level in ${levels}; do
 			#let color_number=$color_number+1
 		done
 
-		# ----- ukmet -----
-		gdfn=ukmet # gd file name
-		if [ -e ${gdfn} ]; then
-			cat >> cmdfilesam  <<- EOF
-				GDFILE  = ${gdfn}
-				LINE    = 7/2/2/0
-				GDATTIM = F${fcsthr_ecm}
-				TITLE   = 7/-4/~ ? UKMET ${ECM_cyc}Z (DASHED)|~${name} ${level} DM
-				run
-
-				EOF
-			if [ $WrottenZERO -eq 0 ]; then            
-				cat >> cmdfilesam  <<- EOF
-					MAP     = 0
-					LATLON  = 0
-					CLEAR   = no
-
-					EOF
-			fi
-			WrottenZERO=1
-		fi
 
 		# ----- ecmwf -----
 		gdfn=ecmwf # gd file name
@@ -370,18 +337,6 @@ for level in ${levels}; do
 			WrottenZERO=1
 		fi
 
-		# ----- dgex -----
-		gdfn=dgex # gd file name
-		if [ -e ${gdfn} ]; then
-			cat >> cmdfilesam  <<- EOF
-				GDFILE  = ${gdfn} 
-				LINE    = 13/2/2/0
-				GDATTIM = F${fcsthr}
-				TITLE   = 13/-7/~ ? ${cyc}Z DGEX|~${name} ${level} DM
-				run
-
-			EOF
-		fi
 
 		cat cmdfilesam
 		gdplot2_nc < cmdfilesam

--- a/jobs/JGEFS_ATMOS_GEMPAK_META
+++ b/jobs/JGEFS_ATMOS_GEMPAK_META
@@ -88,10 +88,7 @@ for config in $configs; do
 done
 
 export COMINsgfs=${COMINsgfs:-$(compath.py $envir/com/gfs/${gfs_ver})}
-export COMINnawips=${COMINnawips:-$(compath.py $envir/com/nawips/${nawips_ver})}
 export COMINecmwf=${COMINecmwf:-$(compath.py $envir/com/ecmwf/${ecmwf_ver})/ecmwf}
-#export COMINukmet=${COMINukmet:-$(compath.py $envir/com/nawips/${nawips_ver})/ukmet}
-export COMINukmet=${COMINukmet:-$(compath.py $envir/com/ukmet/${ukmet_ver})/ukmet}
 export COMINnam=${COMINnam:-$(compath.py $envir/com/nam/${nam_ver})}
 
 export COMPONENT=${COMPONENT:-atmos}

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,12 +1,10 @@
-export gefs_ver=v12.3.13
+export gefs_ver=v12.3.17
 
 export gfs_ver=v16.3
 export cfs_ver=v2.3
 export ecmwf_ver=v2.1
-export nawips_ver=v0.0
 export nam_ver=v4.2
 export obsproc_ver=v1.2
-export ukmet_ver=v2.2
 
 export envvar_ver=1.0
 export intel_ver=19.1.3.304
@@ -42,6 +40,6 @@ export MAIL_LIST="Bing.Fu@noaa.gov,Walter.Kolczynski@noaa.gov,Eric.Sinsky@noaa.g
 
 #export MAILTO="ethan.collins@noaa.gov"
 #export MAIL_LIST="ethan.collins@noaa.gov"
-#export COMPATH=/lfs/h1/ops/prod/com/gfs:/lfs/h1/ops/prod/com/cfs:/lfs/h1/ops/prod/com/nawips:/lfs/h1/ops/prod/com/ecmwf:/lfs/h1/ops/prod/com/nam:/lfs/h1/ops/prod/com/obsproc:/lfs/h1/ops/prod/com/ukmet
+#export COMPATH=/lfs/h1/ops/prod/com/gfs:/lfs/h1/ops/prod/com/cfs:/lfs/h1/ops/prod/com/ecmwf:/lfs/h1/ops/prod/com/nam:/lfs/h1/ops/prod/com/obsproc
 #export DCOMROOT=/lfs/h1/ops/prod/dcom
 #export DBNLOG=YES


### PR DESCRIPTION
This PR syncs NCO's changes to the ops branch. The following changes were made by NCO:

- Update `gefs_ver` to `v12.3.17` 
- Remove unused model references (e.g. ukmet, dgex) in `versions/run.ver`, `jobs/JGEFS_ATMOS_GEMPAK_META` and various gempak/ush scripts. 

Refs #164 