### PR TITLE
Add bugfix for wave_stat task

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -15,7 +15,7 @@ if [[ ! -d global-workflow.fd ]] ; then
     rm -f ${logs_dir}/checkout-global-workflow.log
     git clone https://github.com/NOAA-EMC/global-workflow.git global-workflow.fd >>  ${logs_dir}/checkout-global-workflow.log 2>&1
     cd global-workflow.fd
-    git checkout gefs_v12.3.13
+    git checkout gefs_v12.3.18-0
     cd sorc
     ./checkout.sh
     ERR=$?

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.3.17
+export gefs_ver=v12.3.18
 
 export gfs_ver=v16.3
 export cfs_ver=v2.3
@@ -36,7 +36,7 @@ export cfp_ver=2.0.4
 export USE_CFP=YES
 export PATH=$PATH:.
 
-export MAIL_LIST="Bing.Fu@noaa.gov,Walter.Kolczynski@noaa.gov,Eric.Sinsky@noaa.gov,nco.spa@noaa.gov"
+export MAIL_LIST="Bing.Fu@noaa.gov,Eric.Sinsky@noaa.gov,nco.spa@noaa.gov"
 
 #export MAILTO="ethan.collins@noaa.gov"
 #export MAIL_LIST="ethan.collins@noaa.gov"


### PR DESCRIPTION
This PR adds a bugfix to wave_stat that ensure all ensemble statistics are written to files in bull_tar and station_tar. Other minor changes include:

- Update `gefs_ver` to `v12.3.18`
- Update `MAIL_LIST` to include current POCs