### PR TITLE
Update version number variable for v12.4

### DIFF
--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.3.20
+export gefs_ver=v12.4.0
 
 export gfs_ver=v16.3
 export cfs_ver=v2.3


### PR DESCRIPTION
This PR adds a minor update that is needed for GEFSv12.4. 

- `gefs_ver` in `versions/run.ver` is updated to `v12.4.0`

Addresses #176 