### PR TITLE
Add various changes needed for GEFSv12 to run alongside GFSv17

### DIFF
--- a/ecf/def/gefs_prod00.def
+++ b/ecf/def/gefs_prod00.def
@@ -5,22 +5,22 @@ suite prod
         edit PROJ 'GEFS'
         edit PACKAGEHOME '/lfs/h1/ops/%ENVIR%/packages/gefs.%gefs_ver%'
         defstatus complete
-        family v12.2
+        family v12.4
           family init
             family atmos
               task jgefs_atmos_getcfssst
-                trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
               task jgefs_atmos_init_recenter
                 trigger ( ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq complete )
             endfamily
             family wave
               task jgefs_wave_init
-                trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
             endfamily
           endfamily
           family chem
             task jgefs_chem_prep_emissions
-              trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+              trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
             task jgefs_chem_init
               trigger jgefs_chem_prep_emissions eq complete and ../init/atmos/jgefs_atmos_init_recenter eq complete
             task jgefs_chem_forecast
@@ -46,7 +46,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -76,7 +76,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -106,7 +106,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -136,7 +136,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -166,7 +166,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -196,7 +196,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -226,7 +226,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -256,7 +256,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -286,7 +286,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -316,7 +316,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -346,7 +346,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -376,7 +376,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -406,7 +406,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -436,7 +436,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -466,7 +466,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -496,7 +496,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -526,7 +526,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -556,7 +556,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -586,7 +586,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -616,7 +616,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -646,7 +646,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -676,7 +676,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -706,7 +706,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -736,7 +736,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -766,7 +766,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -796,7 +796,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -826,7 +826,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -856,7 +856,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -886,7 +886,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -916,7 +916,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -946,7 +946,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -1069,7 +1069,7 @@ suite prod
             family d0_16
               family atmos
                 task jgefs_atmos_prdgen_gfs
-                  trigger /prod/primary/00/gfs/v16.2/gfs/atmos/post/jgfs_atmos_post_manager:release_post000
+                  trigger /prod/primary/00/gfs/v17.0/gfs/atmos/post/jgfs_atmos_post_manager:release_post000
                 task jgefs_atmos_ensstat
                   trigger ( ../../../members/d0_16/c00/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/c00/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p01/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p01/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p02/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p02/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p03/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p03/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p04/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p04/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p05/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p05/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p06/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p06/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p07/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p07/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p08/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p08/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p09/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p09/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p10/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p10/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p11/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p11/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p12/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p12/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p13/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p13/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p14/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p14/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p15/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p15/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p16/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p16/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p17/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p17/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p18/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p18/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p19/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p19/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p20/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p20/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p21/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p21/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p22/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p22/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p23/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p23/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p24/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p24/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p25/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p25/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p26/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p26/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p27/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p27/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p28/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p28/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p29/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p29/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p30/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p30/atmos/jgefs_atmos_prdgen eq complete )
                 task jgefs_atmos_enspost
@@ -1099,12 +1099,12 @@ suite prod
           endfamily
           family cleanup
             task jgefs_atmos_post_cleanup
-             trigger ../init eq complete and ../chem eq complete and ../members eq complete and ../post_processing eq complete and ../gempak eq complete and /prod/primary/18/gefs/v12.2/members/d16_35 == complete and /prod/primary/18/gefs/v12.2/post_processing/d16_35 == complete
+             trigger ../init eq complete and ../chem eq complete and ../members eq complete and ../post_processing eq complete and ../gempak eq complete and /prod/primary/18/gefs/v12.4/members/d16_35 == complete and /prod/primary/18/gefs/v12.4/post_processing/d16_35 == complete
           endfamily
-        endfamily # v12.2
+        endfamily # v12.4
       endfamily # gefs
       family gfs
-        family v16.2
+        family v17.0
           family gfs
             family atmos
               family analysis
@@ -1115,12 +1115,12 @@ suite prod
               endfamily # post
             endfamily # atmos 
           endfamily # gfs
-        endfamily # v16.2
+        endfamily # v17.0
       endfamily # gfs
     endfamily # 00
     family 18
       family gefs
-        family v12.2
+        family v12.4
           family members
             family d16_35
             endfamily # d16_35
@@ -1129,7 +1129,7 @@ suite prod
             family d16_35
             endfamily # d16_35
           endfamily # post_processing
-        endfamily #v12.2
+        endfamily #v12.4
       endfamily # gefs
     endfamily # 18
   endfamily # primary

--- a/ecf/def/gefs_prod00.def
+++ b/ecf/def/gefs_prod00.def
@@ -9,18 +9,18 @@ suite prod
           family init
             family atmos
               task jgefs_atmos_getcfssst
-                trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
               task jgefs_atmos_init_recenter
                 trigger ( ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq complete )
             endfamily
             family wave
               task jgefs_wave_init
-                trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
             endfamily
           endfamily
           family chem
             task jgefs_chem_prep_emissions
-              trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+              trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
             task jgefs_chem_init
               trigger jgefs_chem_prep_emissions eq complete and ../init/atmos/jgefs_atmos_init_recenter eq complete
             task jgefs_chem_forecast
@@ -46,7 +46,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -76,7 +76,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -106,7 +106,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -136,7 +136,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -166,7 +166,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -196,7 +196,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -226,7 +226,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -256,7 +256,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -286,7 +286,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -316,7 +316,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -346,7 +346,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -376,7 +376,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -406,7 +406,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -436,7 +436,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -466,7 +466,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -496,7 +496,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -526,7 +526,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -556,7 +556,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -586,7 +586,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -616,7 +616,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -646,7 +646,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -676,7 +676,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -706,7 +706,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -736,7 +736,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -766,7 +766,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -796,7 +796,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -826,7 +826,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -856,7 +856,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -886,7 +886,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -916,7 +916,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -946,7 +946,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/00/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/00/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen

--- a/ecf/def/gefs_prod06.def
+++ b/ecf/def/gefs_prod06.def
@@ -5,22 +5,22 @@ suite prod
         edit PROJ 'GEFS'
         edit PACKAGEHOME '/lfs/h1/ops/%ENVIR%/packages/gefs.%gefs_ver%'
         defstatus complete
-        family v12.2
+        family v12.4
           family init
             family atmos
               task jgefs_atmos_getcfssst
-                trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
               task jgefs_atmos_init_recenter
                 trigger ( ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq complete )
             endfamily
             family wave
               task jgefs_wave_init
-                trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
             endfamily
           endfamily
           family chem
             task jgefs_chem_prep_emissions
-              trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+              trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
             task jgefs_chem_init
               trigger jgefs_chem_prep_emissions eq complete and ../init/atmos/jgefs_atmos_init_recenter eq complete
             task jgefs_chem_forecast
@@ -46,7 +46,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -76,7 +76,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -106,7 +106,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -136,7 +136,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -166,7 +166,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -196,7 +196,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -226,7 +226,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -256,7 +256,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -286,7 +286,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -316,7 +316,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -346,7 +346,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -376,7 +376,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -406,7 +406,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -436,7 +436,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -466,7 +466,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -496,7 +496,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -526,7 +526,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -556,7 +556,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -586,7 +586,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -616,7 +616,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -646,7 +646,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -676,7 +676,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -706,7 +706,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -736,7 +736,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -766,7 +766,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -796,7 +796,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -826,7 +826,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -856,7 +856,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -886,7 +886,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -916,7 +916,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -946,7 +946,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -1069,7 +1069,7 @@ suite prod
             family d0_16
               family atmos
                 task jgefs_atmos_prdgen_gfs
-                  trigger /prod/primary/06/gfs/v16.2/gfs/atmos/post/jgfs_atmos_post_manager:release_post000
+                  trigger /prod/primary/06/gfs/v17.0/gfs/atmos/post/jgfs_atmos_post_manager:release_post000
                 task jgefs_atmos_ensstat
                   trigger ( ../../../members/d0_16/c00/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/c00/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p01/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p01/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p02/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p02/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p03/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p03/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p04/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p04/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p05/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p05/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p06/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p06/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p07/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p07/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p08/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p08/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p09/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p09/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p10/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p10/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p11/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p11/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p12/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p12/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p13/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p13/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p14/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p14/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p15/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p15/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p16/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p16/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p17/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p17/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p18/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p18/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p19/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p19/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p20/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p20/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p21/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p21/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p22/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p22/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p23/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p23/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p24/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p24/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p25/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p25/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p26/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p26/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p27/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p27/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p28/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p28/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p29/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p29/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p30/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p30/atmos/jgefs_atmos_prdgen eq complete )
                 task jgefs_atmos_enspost
@@ -1101,10 +1101,10 @@ suite prod
             task jgefs_atmos_post_cleanup
               trigger ../init eq complete and ../chem eq complete and ../members eq complete and ../post_processing eq complete and ../gempak eq complete
           endfamily
-        endfamily # v12.2
+        endfamily # v12.4
       endfamily # gefs
       family gfs
-        family v16.2
+        family v17.0
           family gfs
             family atmos
               family analysis
@@ -1115,7 +1115,7 @@ suite prod
               endfamily # post
             endfamily # atmos
           endfamily # gfs
-        endfamily # v16.2
+        endfamily # v17.0
       endfamily # gfs
     endfamily # 06
   endfamily # primary

--- a/ecf/def/gefs_prod06.def
+++ b/ecf/def/gefs_prod06.def
@@ -9,18 +9,18 @@ suite prod
           family init
             family atmos
               task jgefs_atmos_getcfssst
-                trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
               task jgefs_atmos_init_recenter
                 trigger ( ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq complete )
             endfamily
             family wave
               task jgefs_wave_init
-                trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
             endfamily
           endfamily
           family chem
             task jgefs_chem_prep_emissions
-              trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+              trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
             task jgefs_chem_init
               trigger jgefs_chem_prep_emissions eq complete and ../init/atmos/jgefs_atmos_init_recenter eq complete
             task jgefs_chem_forecast
@@ -46,7 +46,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -76,7 +76,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -106,7 +106,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -136,7 +136,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -166,7 +166,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -196,7 +196,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -226,7 +226,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -256,7 +256,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -286,7 +286,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -316,7 +316,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -346,7 +346,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -376,7 +376,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -406,7 +406,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -436,7 +436,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -466,7 +466,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -496,7 +496,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -526,7 +526,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -556,7 +556,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -586,7 +586,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -616,7 +616,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -646,7 +646,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -676,7 +676,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -706,7 +706,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -736,7 +736,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -766,7 +766,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -796,7 +796,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -826,7 +826,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -856,7 +856,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -886,7 +886,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -916,7 +916,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -946,7 +946,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/06/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/06/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen

--- a/ecf/def/gefs_prod12.def
+++ b/ecf/def/gefs_prod12.def
@@ -9,18 +9,18 @@ suite prod
           family init
             family atmos
               task jgefs_atmos_getcfssst
-                trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis == complete
+                trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos == complete
               task jgefs_atmos_init_recenter
                 trigger ( ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq complete )
             endfamily
             family wave
               task jgefs_wave_init
-                trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
             endfamily
           endfamily
           family chem
             task jgefs_chem_prep_emissions
-              trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+              trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
             task jgefs_chem_init
               trigger jgefs_chem_prep_emissions eq complete and ../init/atmos/jgefs_atmos_init_recenter eq complete
             task jgefs_chem_forecast
@@ -46,7 +46,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -76,7 +76,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -106,7 +106,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -136,7 +136,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -166,7 +166,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -196,7 +196,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -226,7 +226,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -256,7 +256,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -286,7 +286,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -316,7 +316,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -346,7 +346,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -376,7 +376,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -406,7 +406,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -436,7 +436,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -466,7 +466,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -496,7 +496,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -526,7 +526,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -556,7 +556,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -586,7 +586,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -616,7 +616,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -646,7 +646,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -676,7 +676,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -706,7 +706,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -736,7 +736,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -766,7 +766,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -796,7 +796,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -826,7 +826,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -856,7 +856,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -886,7 +886,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -916,7 +916,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -946,7 +946,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/analysis/atmos/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen

--- a/ecf/def/gefs_prod12.def
+++ b/ecf/def/gefs_prod12.def
@@ -5,22 +5,22 @@ suite prod
         edit PROJ 'GEFS'
         edit PACKAGEHOME '/lfs/h1/ops/%ENVIR%/packages/gefs.%gefs_ver%'
         defstatus complete
-        family v12.2
+        family v12.4
           family init
             family atmos
               task jgefs_atmos_getcfssst
-                trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis == complete
+                trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis == complete
               task jgefs_atmos_init_recenter
                 trigger ( ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq complete )
             endfamily
             family wave
               task jgefs_wave_init
-                trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
             endfamily
           endfamily
           family chem
             task jgefs_chem_prep_emissions
-              trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+              trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
             task jgefs_chem_init
               trigger jgefs_chem_prep_emissions eq complete and ../init/atmos/jgefs_atmos_init_recenter eq complete
             task jgefs_chem_forecast
@@ -46,7 +46,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -76,7 +76,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -106,7 +106,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -136,7 +136,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -166,7 +166,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -196,7 +196,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -226,7 +226,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -256,7 +256,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -286,7 +286,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -316,7 +316,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -346,7 +346,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -376,7 +376,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -406,7 +406,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -436,7 +436,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -466,7 +466,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -496,7 +496,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -526,7 +526,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -556,7 +556,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -586,7 +586,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -616,7 +616,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -646,7 +646,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -676,7 +676,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -706,7 +706,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -736,7 +736,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -766,7 +766,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -796,7 +796,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -826,7 +826,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -856,7 +856,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -886,7 +886,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -916,7 +916,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -946,7 +946,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/12/gfs/v16.2/gfs/atmos/analysis/jgfs_atmos_analysis == complete
+                    trigger /prod/primary/12/gfs/v17.0/gfs/atmos/analysis/jgfs_atmos_analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -1069,7 +1069,7 @@ suite prod
             family d0_16
               family atmos
                 task jgefs_atmos_prdgen_gfs
-                  trigger /prod/primary/12/gfs/v16.2/gfs/atmos/post/jgfs_atmos_post_manager:release_post000
+                  trigger /prod/primary/12/gfs/v17.0/gfs/atmos/post/jgfs_atmos_post_manager:release_post000
                 task jgefs_atmos_ensstat
                   trigger ( ../../../members/d0_16/c00/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/c00/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p01/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p01/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p02/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p02/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p03/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p03/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p04/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p04/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p05/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p05/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p06/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p06/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p07/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p07/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p08/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p08/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p09/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p09/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p10/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p10/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p11/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p11/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p12/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p12/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p13/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p13/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p14/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p14/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p15/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p15/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p16/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p16/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p17/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p17/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p18/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p18/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p19/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p19/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p20/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p20/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p21/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p21/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p22/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p22/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p23/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p23/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p24/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p24/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p25/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p25/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p26/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p26/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p27/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p27/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p28/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p28/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p29/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p29/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p30/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p30/atmos/jgefs_atmos_prdgen eq complete )
                 task jgefs_atmos_enspost
@@ -1101,10 +1101,10 @@ suite prod
             task jgefs_atmos_post_cleanup
               trigger ../init eq complete and ../chem eq complete and ../members eq complete and ../post_processing eq complete and ../gempak eq complete
           endfamily
-        endfamily # v12.2
+        endfamily # v12.4
       endfamily # gefs
       family gfs
-        family v16.2
+        family v17.0
           family gfs
             family atmos
               family analysis
@@ -1116,7 +1116,7 @@ suite prod
               endfamily # post
             endfamily # atmos
           endfamily # gfs
-        endfamily # v16.2
+        endfamily # v17.0
       endfamily # gfs
     endfamily # 12
   endfamily # primary

--- a/ecf/def/gefs_prod18.def
+++ b/ecf/def/gefs_prod18.def
@@ -9,18 +9,18 @@ suite prod
           family init
             family atmos
               task jgefs_atmos_getcfssst
-                trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
               task jgefs_atmos_init_recenter
                 trigger ( ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq complete )
             endfamily
             family wave
               task jgefs_wave_init
-                trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
             endfamily
           endfamily
           family chem
             task jgefs_chem_prep_emissions
-              trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+              trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
             task jgefs_chem_init
               trigger jgefs_chem_prep_emissions eq complete and ../init/atmos/jgefs_atmos_init_recenter eq complete
             task jgefs_chem_forecast
@@ -46,7 +46,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -76,7 +76,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -106,7 +106,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -136,7 +136,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -166,7 +166,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -196,7 +196,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -226,7 +226,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -256,7 +256,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -286,7 +286,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -316,7 +316,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -346,7 +346,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -376,7 +376,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -406,7 +406,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -436,7 +436,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -466,7 +466,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -496,7 +496,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -526,7 +526,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -556,7 +556,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -586,7 +586,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -616,7 +616,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -646,7 +646,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -676,7 +676,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -706,7 +706,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -736,7 +736,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -766,7 +766,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -796,7 +796,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -826,7 +826,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -856,7 +856,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -886,7 +886,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -916,7 +916,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -946,7 +946,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/analysis/atmos == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen

--- a/ecf/def/gefs_prod18.def
+++ b/ecf/def/gefs_prod18.def
@@ -5,22 +5,22 @@ suite prod
         edit PROJ 'GEFS'
         edit PACKAGEHOME '/lfs/h1/ops/%ENVIR%/packages/gefs.%gefs_ver%'
         defstatus complete
-        family v12.2
+        family v12.4
           family init
             family atmos
               task jgefs_atmos_getcfssst
-                trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
               task jgefs_atmos_init_recenter
                 trigger ( ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/c00/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p01/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p02/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p03/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p04/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p05/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p06/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p07/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p08/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p09/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p10/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p11/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p12/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p13/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p14/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p15/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p16/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p17/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p18/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p19/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p20/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p21/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p22/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p23/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p24/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p25/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p26/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p27/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p28/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p29/atmos/jgefs_atmos_prep eq complete ) and ( ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq active or ../../members/d0_16/p30/atmos/jgefs_atmos_prep eq complete )
             endfamily
             family wave
               task jgefs_wave_init
-                trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
             endfamily
           endfamily
           family chem
             task jgefs_chem_prep_emissions
-              trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+              trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
             task jgefs_chem_init
               trigger jgefs_chem_prep_emissions eq complete and ../init/atmos/jgefs_atmos_init_recenter eq complete
             task jgefs_chem_forecast
@@ -46,7 +46,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -76,7 +76,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -106,7 +106,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -136,7 +136,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -166,7 +166,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -196,7 +196,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -226,7 +226,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -256,7 +256,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -286,7 +286,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -316,7 +316,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -346,7 +346,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -376,7 +376,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -406,7 +406,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -436,7 +436,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -466,7 +466,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -496,7 +496,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -526,7 +526,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -556,7 +556,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -586,7 +586,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -616,7 +616,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -646,7 +646,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -676,7 +676,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -706,7 +706,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -736,7 +736,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -766,7 +766,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -796,7 +796,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -826,7 +826,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -856,7 +856,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -886,7 +886,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -916,7 +916,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -946,7 +946,7 @@ suite prod
                   event 5 gefswave_f240_ready
                 family atmos
                   task jgefs_atmos_prep
-                    trigger /prod/primary/18/gfs/v16.2/gfs/atmos/analysis == complete
+                    trigger /prod/primary/18/gfs/v17.0/gfs/atmos/analysis == complete
                   task jgefs_atmos_post
                     trigger ../jgefs_fcst_post_manager:release_post
                   task jgefs_atmos_prdgen
@@ -1058,7 +1058,7 @@ suite prod
             family d0_16
               family atmos
                 task jgefs_atmos_prdgen_gfs
-                  trigger /prod/primary/18/gfs/v16.2/gfs/atmos/post/jgfs_atmos_post_manager:release_post000
+                  trigger /prod/primary/18/gfs/v17.0/gfs/atmos/post/jgfs_atmos_post_manager:release_post000
                 task jgefs_atmos_ensstat
                   trigger ( ../../../members/d0_16/c00/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/c00/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p01/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p01/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p02/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p02/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p03/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p03/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p04/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p04/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p05/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p05/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p06/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p06/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p07/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p07/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p08/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p08/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p09/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p09/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p10/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p10/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p11/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p11/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p12/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p12/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p13/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p13/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p14/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p14/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p15/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p15/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p16/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p16/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p17/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p17/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p18/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p18/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p19/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p19/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p20/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p20/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p21/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p21/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p22/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p22/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p23/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p23/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p24/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p24/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p25/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p25/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p26/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p26/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p27/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p27/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p28/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p28/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p29/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p29/atmos/jgefs_atmos_prdgen eq complete ) and ( ../../../members/d0_16/p30/atmos/jgefs_atmos_prdgen eq active or ../../../members/d0_16/p30/atmos/jgefs_atmos_prdgen eq complete )
                 task jgefs_atmos_enspost
@@ -1100,10 +1100,10 @@ suite prod
             task jgefs_atmos_post_cleanup
               trigger ../init eq complete and ../chem eq complete and ../members eq complete and ../post_processing eq complete and ../gempak eq complete
           endfamily
-        endfamily # v12.2
+        endfamily # v12.4
       endfamily # gefs
       family gfs
-        family v16.2
+        family v17.0
           family gfs
             family atmos
               family analysis
@@ -1115,7 +1115,7 @@ suite prod
               endfamily # post
             endfamily # atmos
           endfamily # gfs
-        endfamily # v16.2
+        endfamily # v17.0
       endfamily # gfs
     endfamily # 18
   endfamily # primary

--- a/gempak/ush/gefs_meta_850.sh_comb
+++ b/gempak/ush/gefs_meta_850.sh_comb
@@ -94,14 +94,14 @@ for area in us sam; do
 
 			fn=gfs
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 			fi
 
 			fn=gfs_6
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/gempak/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-				ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/gempak/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+			if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+				ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 			fi
 
 			fn=ecmwf

--- a/gempak/ush/gefs_meta_850.sh_comb
+++ b/gempak/ush/gefs_meta_850.sh_comb
@@ -94,14 +94,14 @@ for area in us sam; do
 
 			fn=gfs
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 			fi
 
 			fn=gfs_6
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-				ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+			if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+				ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 			fi
 
 			fn=ecmwf

--- a/gempak/ush/gefs_meta_850.sh_comb
+++ b/gempak/ush/gefs_meta_850.sh_comb
@@ -94,14 +94,14 @@ for area in us sam; do
 
 			fn=gfs
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 			fi
 
 			fn=gfs_6
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-				ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+			if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+				ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 			fi
 
 			fn=ecmwf

--- a/gempak/ush/gefs_meta_carib_spag.sh_comb
+++ b/gempak/ush/gefs_meta_carib_spag.sh_comb
@@ -101,8 +101,8 @@ for pres in 200 250 300; do
 
 			fn=gfs
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 			fi
 
 			fn=gfs_6

--- a/gempak/ush/gefs_meta_carib_spag.sh_comb
+++ b/gempak/ush/gefs_meta_carib_spag.sh_comb
@@ -107,8 +107,8 @@ for pres in 200 250 300; do
 
 			fn=gfs_6
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/gempak/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-				ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/gempak/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+			if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+				ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 			fi
 
 			fn=ecmwf

--- a/gempak/ush/gefs_meta_carib_spag.sh_comb
+++ b/gempak/ush/gefs_meta_carib_spag.sh_comb
@@ -101,8 +101,8 @@ for pres in 200 250 300; do
 
 			fn=gfs
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 			fi
 
 			fn=gfs_6

--- a/gempak/ush/gefs_meta_carib_spag.sh_comb
+++ b/gempak/ush/gefs_meta_carib_spag.sh_comb
@@ -101,14 +101,14 @@ for pres in 200 250 300; do
 
 			fn=gfs
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 			fi
 
 			fn=gfs_6
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-				ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+			if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+				ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 			fi
 
 			fn=ecmwf

--- a/gempak/ush/gefs_meta_hi_spag.sh_comb
+++ b/gempak/ush/gefs_meta_hi_spag.sh_comb
@@ -86,14 +86,14 @@ for level in ${levels}; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=gfs_6
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 		fi
 
 		fn=ecmwf

--- a/gempak/ush/gefs_meta_hi_spag.sh_comb
+++ b/gempak/ush/gefs_meta_hi_spag.sh_comb
@@ -86,14 +86,14 @@ for level in ${levels}; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=gfs_6
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/gempak/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/gempak/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 		fi
 
 		fn=ecmwf

--- a/gempak/ush/gefs_meta_hi_spag.sh_comb
+++ b/gempak/ush/gefs_meta_hi_spag.sh_comb
@@ -86,14 +86,14 @@ for level in ${levels}; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=gfs_6
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 		fi
 
 		fn=ecmwf

--- a/gempak/ush/gefs_meta_lows.sh_comb
+++ b/gempak/ush/gefs_meta_lows.sh_comb
@@ -113,14 +113,14 @@ for area in nam us trop sam hi; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=gfs_6
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 		fi
 
 		fn=ecmwf

--- a/gempak/ush/gefs_meta_lows.sh_comb
+++ b/gempak/ush/gefs_meta_lows.sh_comb
@@ -119,8 +119,8 @@ for area in nam us trop sam hi; do
 
 		fn=gfs_6
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/gempak/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/gempak/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 		fi
 
 		fn=ecmwf

--- a/gempak/ush/gefs_meta_lows.sh_comb
+++ b/gempak/ush/gefs_meta_lows.sh_comb
@@ -113,8 +113,8 @@ for area in nam us trop sam hi; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=gfs_6

--- a/gempak/ush/gefs_meta_lows.sh_comb
+++ b/gempak/ush/gefs_meta_lows.sh_comb
@@ -113,8 +113,8 @@ for area in nam us trop sam hi; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=gfs_6

--- a/gempak/ush/gefs_meta_mar_00Z.sh
+++ b/gempak/ush/gefs_meta_mar_00Z.sh
@@ -77,8 +77,8 @@ for metaarea in pac atl; do
 
 			fn=gfs
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/0p50/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ]; then
-				ln -s $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/0p50/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ${fn}
+			if [ -r $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ]; then
+				ln -s $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ${fn}
 			fi
 
 			fn=ecmwf
@@ -244,8 +244,8 @@ for metaarea in pac atl; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/0p50/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ]; then
-			ln -s $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/0p50/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ${fn}
+		if [ -r $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ]; then
+			ln -s $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ${fn}
 		fi
 
 		fn=ecmwf

--- a/gempak/ush/gefs_meta_mar_00Z.sh
+++ b/gempak/ush/gefs_meta_mar_00Z.sh
@@ -77,8 +77,8 @@ for metaarea in pac atl; do
 
 			fn=gfs
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${yesterday}/${gfscyc}/gempak/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ]; then
-				ln -s $COMINsgfs/gfs.${yesterday}/${gfscyc}/gempak/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ${fn}
+			if [ -r $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/0p50/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ]; then
+				ln -s $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/0p50/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ${fn}
 			fi
 
 			fn=ecmwf
@@ -244,8 +244,8 @@ for metaarea in pac atl; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${yesterday}/${gfscyc}/gempak/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ]; then
-			ln -s $COMINsgfs/gfs.${yesterday}/${gfscyc}/gempak/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ${fn}
+		if [ -r $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/0p50/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ]; then
+			ln -s $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/0p50/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ${fn}
 		fi
 
 		fn=ecmwf

--- a/gempak/ush/gefs_meta_mar_00Z.sh
+++ b/gempak/ush/gefs_meta_mar_00Z.sh
@@ -77,8 +77,8 @@ for metaarea in pac atl; do
 
 			fn=gfs
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ]; then
-				ln -s $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ${fn}
+			if [ -r $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ]; then
+				ln -s $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ${fn}
 			fi
 
 			fn=ecmwf
@@ -244,8 +244,8 @@ for metaarea in pac atl; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ]; then
-			ln -s $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ${fn}
+		if [ -r $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ]; then
+			ln -s $COMINsgfs/gfs.${yesterday}/${gfscyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${yesterday}${gfscyc}f${fcsthrsgfs} ${fn}
 		fi
 
 		fn=ecmwf

--- a/gempak/ush/gefs_meta_mar_12Z.sh
+++ b/gempak/ush/gefs_meta_mar_12Z.sh
@@ -70,8 +70,8 @@ for metaarea in pac atl; do
 
 			fn=gfs
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 			fi
 
 			fn=nam
@@ -216,8 +216,8 @@ for metaarea in pac atl; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=nam

--- a/gempak/ush/gefs_meta_mar_12Z.sh
+++ b/gempak/ush/gefs_meta_mar_12Z.sh
@@ -70,8 +70,8 @@ for metaarea in pac atl; do
 
 			fn=gfs
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 			fi
 
 			fn=nam
@@ -216,8 +216,8 @@ for metaarea in pac atl; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=nam

--- a/gempak/ush/gefs_meta_mar_12Z.sh
+++ b/gempak/ush/gefs_meta_mar_12Z.sh
@@ -70,8 +70,8 @@ for metaarea in pac atl; do
 
 			fn=gfs
 			rm -rf ${fn}
-			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+			if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 			fi
 
 			fn=nam
@@ -216,8 +216,8 @@ for metaarea in pac atl; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=nam

--- a/gempak/ush/gefs_meta_nam_spag.sh_comb
+++ b/gempak/ush/gefs_meta_nam_spag.sh_comb
@@ -108,14 +108,14 @@ for level in ${levels}; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=gfs_6
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/gempak/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/gempak/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 		fi
 
 		fn=ecmwf

--- a/gempak/ush/gefs_meta_nam_spag.sh_comb
+++ b/gempak/ush/gefs_meta_nam_spag.sh_comb
@@ -108,14 +108,14 @@ for level in ${levels}; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=gfs_6
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 		fi
 
 		fn=ecmwf

--- a/gempak/ush/gefs_meta_nam_spag.sh_comb
+++ b/gempak/ush/gefs_meta_nam_spag.sh_comb
@@ -108,14 +108,14 @@ for level in ${levels}; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=gfs_6
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+			ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 		fi
 
 		fn=ecmwf

--- a/gempak/ush/gefs_meta_qpf.sh
+++ b/gempak/ush/gefs_meta_qpf.sh
@@ -59,8 +59,8 @@ for fcsthr in ${fcsthrs}; do
 
 	fn=gfs
 	rm -rf ${fn}
-	if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-		ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+	if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+		ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 	fi
 
 	if [ ${cyc} = "00" ]; then
@@ -284,7 +284,7 @@ for area in us sam us12 us24; do
 	fi
 	
 	ln -s $COMIN/ge*${sGrid}_${PDY}${cyc}f* ./
-	ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f* ./
+	ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f* ./
 	#ln -s $COMINecmwf.${PDYm1}/gempak/ecmwf_hr_${PDYm1}${cycm12}f* ./
 	#ln -s $COMINecmwf.${PDY}/gempak/ecmwf_hr_${PDY}${cycm12}f* ./
 	for grid in ${grids}; do

--- a/gempak/ush/gefs_meta_qpf.sh
+++ b/gempak/ush/gefs_meta_qpf.sh
@@ -59,8 +59,8 @@ for fcsthr in ${fcsthrs}; do
 
 	fn=gfs
 	rm -rf ${fn}
-	if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-		ln -s $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+	if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+		ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 	fi
 
 	if [ ${cyc} = "00" ]; then
@@ -284,7 +284,7 @@ for area in us sam us12 us24; do
 	fi
 	
 	ln -s $COMIN/ge*${sGrid}_${PDY}${cyc}f* ./
-	ln -s $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f* ./
+	ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f* ./
 	#ln -s $COMINecmwf.${PDYm1}/gempak/ecmwf_hr_${PDYm1}${cycm12}f* ./
 	#ln -s $COMINecmwf.${PDY}/gempak/ecmwf_hr_${PDY}${cycm12}f* ./
 	for grid in ${grids}; do
@@ -295,7 +295,6 @@ for area in us sam us12 us24; do
 		if [ ${grid} = "GFS" ]; then
 			GDFILE="F-GFS | ${ddate}/${cyc}00"
 			COMINtmp=$COMIN
-			# #export COMIN=$COMINsgfs/gfs.${PDY}/${cyc}/gempak
 			export COMIN=./
 		elif [ ${grid} = "ECMWF" ]; then
 			if [ $cyc = "12" ]; then

--- a/gempak/ush/gefs_meta_qpf.sh
+++ b/gempak/ush/gefs_meta_qpf.sh
@@ -59,8 +59,8 @@ for fcsthr in ${fcsthrs}; do
 
 	fn=gfs
 	rm -rf ${fn}
-	if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-		ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+	if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+		ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 	fi
 
 	if [ ${cyc} = "00" ]; then
@@ -284,7 +284,7 @@ for area in us sam us12 us24; do
 	fi
 	
 	ln -s $COMIN/ge*${sGrid}_${PDY}${cyc}f* ./
-	ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f* ./
+	ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f* ./
 	#ln -s $COMINecmwf.${PDYm1}/gempak/ecmwf_hr_${PDYm1}${cycm12}f* ./
 	#ln -s $COMINecmwf.${PDY}/gempak/ecmwf_hr_${PDY}${cycm12}f* ./
 	for grid in ${grids}; do

--- a/gempak/ush/gefs_meta_sam_spag.sh_comb
+++ b/gempak/ush/gefs_meta_sam_spag.sh_comb
@@ -111,14 +111,14 @@ for level in ${levels}; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			 ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			 ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=gfs_6
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-			 ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+			 ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 		fi
 
 		fn=ecmwf

--- a/gempak/ush/gefs_meta_sam_spag.sh_comb
+++ b/gempak/ush/gefs_meta_sam_spag.sh_comb
@@ -111,14 +111,14 @@ for level in ${levels}; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			 ln -s $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			 ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=gfs_6
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/gempak/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-			 ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/gempak/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+			 ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/0p50/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 		fi
 
 		fn=ecmwf

--- a/gempak/ush/gefs_meta_sam_spag.sh_comb
+++ b/gempak/ush/gefs_meta_sam_spag.sh_comb
@@ -111,14 +111,14 @@ for level in ${levels}; do
 
 		fn=gfs
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
-			 ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
+			 ln -s $COMINsgfs/gfs.${PDY}/${cyc}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		fn=gfs_6
 		rm -rf ${fn}
-		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
-			 ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
+		if [ -r $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ]; then
+			 ln -s $COMINsgfs/gfs.${PDY_6}/${cyc_6}/products/atmos/gempak/${sGrid#_}/gfs${sGrid}_${PDY_6}${cyc_6}f${fcsthr_6} ${fn}
 		fi
 
 		fn=ecmwf

--- a/jobs/JGEFS_ATMOS_GETCFSSST
+++ b/jobs/JGEFS_ATMOS_GETCFSSST
@@ -77,7 +77,7 @@ for config in $configs; do
     fi
 done
 
-export COMINgfs=${COMINgfs:-$(compath.py ${envir}/com/gfs/${gfs_ver})/gfs.${PDY}/$cyc/atmos}
+export COMINgfs=${COMINgfs:-$(compath.py ${envir}/com/gfs/${gfs_ver})/gfs.${PDY}/$cyc}
 export COMINcfs=${COMINcfs:-$(compath.py ${envir}/com/cfs/${cfs_ver})/cfs.}
 
 echo "Environment before calling script"

--- a/jobs/JGEFS_ATMOS_PRDGEN
+++ b/jobs/JGEFS_ATMOS_PRDGEN
@@ -90,7 +90,7 @@ for config in $configs; do
     fi
 done
 
-export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}/$cyc/atmos}
+export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}/$cyc}
 
 if [[ $cplchm = ".true." ]]; then
     COMPONENT="chem"

--- a/jobs/JGEFS_ATMOS_PREP
+++ b/jobs/JGEFS_ATMOS_PREP
@@ -84,8 +84,8 @@ for config in $configs; do
     fi
 done
 
-export COMINgfs=${COMINgfs:-$(compath.py ${envir}/com/gfs/${gfs_ver})/gfs.${PDY}/${cyc}/atmos}
-export COMINenkf=${COMINenkf:-$(compath.py ${envir}/com/gfs/${gfs_ver})/enkfgdas.${pdyp}/${cycp}/atmos}
+export COMINgfs=${COMINgfs:-$(compath.py ${envir}/com/gfs/${gfs_ver})/gfs.${PDY}/${cyc}}
+export COMINenkf=${COMINenkf:-$(compath.py ${envir}/com/gfs/${gfs_ver})/enkfgdas.${pdyp}/${cycp}}
 
 NCP=${NCP:-"/bin/cp -p"}
 

--- a/jobs/JGEFS_CHEM_INIT
+++ b/jobs/JGEFS_CHEM_INIT
@@ -85,7 +85,7 @@ for config in $configs; do
     fi
 done
 
-export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}/$cyc/atmos}
+export COMINgfs=${COMINgfs:-$(compath.py $envir/com/gfs/${gfs_ver})/gfs.${PDY}/$cyc}
 
 echo "Environment before calling script"
 env | sort

--- a/rocoto/py/user_wcoss2.conf
+++ b/rocoto/py/user_wcoss2.conf
@@ -608,7 +608,7 @@ PRE                             = &GEFS_ROCOTO;/bin/gefs_pre_job.sh
 WORKFLOW_LOG_DIR                = &GEFS_ROCOTO;/logs
 LOG_DIR                         = &WORKDIR;/dev/output
 tmpnwprd                        = &WORKDIR;/tmp
-DATA_DIR                        = &WORKDIR;/dev/com/gefs/v12.3
+DATA_DIR                        = &WORKDIR;/dev/com/gefs/v12.4
 #-------
 XML                             = gefs.xml
 DB                              = gefs.db

--- a/ush/gefs_prdgen_driver.sh
+++ b/ush/gefs_prdgen_driver.sh
@@ -102,8 +102,8 @@ for hour in $hours; do
 		export fhr=000
 
 		if [[ $RUNMEM = "gegfs" ]]; then
-			export mafile=$COMINgfs/gfs.$cycle.master.grb2anl
-			export mifile=$COMINgfs/gfs.$cycle.master.grb2ianl
+			export mafile=$COMINgfs/model/atmos/master/gfs.$cycle.master.analysis.grib2
+			export mifile=$COMINgfs/model/atmos/master/gfs.$cycle.master.analysis.grib2.idx
 			export mcfile=""
 			export makepgrb2b="no"
 		else
@@ -245,8 +245,8 @@ for hour in $hours; do
 	export pgm="postcheck"
 
 	if [[ $RUNMEM = "gegfs" ]]; then
-		export mafile=$COMINgfs/gfs.$cycle.master.grb2f$fhr
-		export mifile=$COMINgfs/gfs.$cycle.master.grb2if$fhr
+		export mafile=$COMINgfs/model/atmos/master/gfs.$cycle.master.f${fhr}.grib2
+		export mifile=$COMINgfs/model/atmos/master/gfs.$cycle.master.f${fhr}.grib2.idx
 		export mcfile=""
 		export makepgrb2b="no"
 	else 


### PR DESCRIPTION
This PR does the following for the gefs.v12.4.0 upgrade:

- Update the location of the gfs gempak data to the location used in gfsv17. This data is needed for the gefs gempak meta task. 
- Modify the default `COMINgfs` and `COMINenkf` for the `getcfssst`, `atmos_prep` and `chem_init` tasks. 
- Modify the triggers and version numbers in the ecf def files to accommodate GFSv17
- Update gfs file path and file name for atmos_prdgen_gfs task

This PR will be left in draft until more testing is performed. 

Addresses https://github.com/NOAA-EMC/GEFS/issues/176