### PR TITLE
Update gfs_ver and gfs analysis master file location

### DIFF
--- a/ush/gefs_prdgen_driver.sh
+++ b/ush/gefs_prdgen_driver.sh
@@ -102,8 +102,8 @@ for hour in $hours; do
 		export fhr=000
 
 		if [[ $RUNMEM = "gegfs" ]]; then
-			export mafile=$COMINgfs/analysis/atmos/master/gfs.$cycle.master.analysis.grib2
-			export mifile=$COMINgfs/analysis/atmos/master/gfs.$cycle.master.analysis.grib2.idx
+			export mafile=$COMINgfs/analysis/atmos/gfs.$cycle.master.analysis.grib2
+			export mifile=$COMINgfs/analysis/atmos/gfs.$cycle.master.analysis.grib2.idx
 			export mcfile=""
 			export makepgrb2b="no"
 		else

--- a/ush/gefs_prdgen_driver.sh
+++ b/ush/gefs_prdgen_driver.sh
@@ -102,8 +102,8 @@ for hour in $hours; do
 		export fhr=000
 
 		if [[ $RUNMEM = "gegfs" ]]; then
-			export mafile=$COMINgfs/model/atmos/master/gfs.$cycle.master.analysis.grib2
-			export mifile=$COMINgfs/model/atmos/master/gfs.$cycle.master.analysis.grib2.idx
+			export mafile=$COMINgfs/analysis/atmos/master/gfs.$cycle.master.analysis.grib2
+			export mifile=$COMINgfs/analysis/atmos/master/gfs.$cycle.master.analysis.grib2.idx
 			export mcfile=""
 			export makepgrb2b="no"
 		else

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,6 +1,6 @@
 export gefs_ver=v12.4.0
 
-export gfs_ver=v16.3
+export gfs_ver=v17.0
 export cfs_ver=v2.3
 export ecmwf_ver=v2.1
 export nam_ver=v4.2


### PR DESCRIPTION
This PR updates `gfs_ver` to `17.0` in `versions/run.ver`. The gfs analysis master file location is also updated to match the changes made in global workflow [PR #4958](https://github.com/NOAA-EMC/global-workflow/pull/4958). 