### PR TITLE
Bring GEFS.v12.3.20 changes to develop branch

### DIFF
--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -15,7 +15,7 @@ if [[ ! -d global-workflow.fd ]] ; then
     rm -f ${logs_dir}/checkout-global-workflow.log
     git clone https://github.com/NOAA-EMC/global-workflow.git global-workflow.fd >>  ${logs_dir}/checkout-global-workflow.log 2>&1
     cd global-workflow.fd
-    git checkout gefs_v12.3.18-0
+    git checkout gefs_v12.3.20-0
     cd sorc
     ./checkout.sh
     ERR=$?

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -15,7 +15,7 @@ if [[ ! -d global-workflow.fd ]] ; then
     rm -f ${logs_dir}/checkout-global-workflow.log
     git clone https://github.com/NOAA-EMC/global-workflow.git global-workflow.fd >>  ${logs_dir}/checkout-global-workflow.log 2>&1
     cd global-workflow.fd
-    git checkout gefs_v12.3.13
+    git checkout gefs_v12.3.18-0
     cd sorc
     ./checkout.sh
     ERR=$?

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.3.17
+export gefs_ver=v12.3.18
 
 export gfs_ver=v16.3
 export cfs_ver=v2.3
@@ -36,10 +36,4 @@ export cfp_ver=2.0.4
 export USE_CFP=YES
 export PATH=$PATH:.
 
-export MAIL_LIST="Bing.Fu@noaa.gov,Walter.Kolczynski@noaa.gov,Eric.Sinsky@noaa.gov,nco.spa@noaa.gov"
-
-#export MAILTO="ethan.collins@noaa.gov"
-#export MAIL_LIST="ethan.collins@noaa.gov"
-#export COMPATH=/lfs/h1/ops/prod/com/gfs:/lfs/h1/ops/prod/com/cfs:/lfs/h1/ops/prod/com/ecmwf:/lfs/h1/ops/prod/com/nam:/lfs/h1/ops/prod/com/obsproc
-#export DCOMROOT=/lfs/h1/ops/prod/dcom
-#export DBNLOG=YES
+export MAIL_LIST="Bing.Fu@noaa.gov,Eric.Sinsky@noaa.gov,nco.spa@noaa.gov"

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.3.18
+export gefs_ver=v12.3.20
 
 export gfs_ver=v16.3
 export cfs_ver=v2.3


### PR DESCRIPTION
This PR brings changes made in the GEFS upgrade (v12.3.20) to `develop`. This PR replaces the previously closed PR #183. 

Resolves https://github.com/NOAA-EMC/GEFS/issues/173