### PR TITLE
Remove NAM products and references 

### DIFF
--- a/gempak/ush/gefs_meta_mar_12Z.sh
+++ b/gempak/ush/gefs_meta_mar_12Z.sh
@@ -74,12 +74,6 @@ for metaarea in pac atl; do
 				ln -s $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
 			fi
 
-			fn=nam
-			rm -rf ${fn}
-			if [ -r $COMINnam/nam.${PDY}/gempak/nam_${PDY}${cyc}f${fcsthr} ]; then
-				ln -s $COMINnam/nam.${PDY}/gempak/nam_${PDY}${cyc}f${fcsthr} ${fn}
-			fi
-
 			cat > cmdfilemar  <<- EOF
 				DEVICE	= ${device}
 				PANEL	= 0
@@ -156,28 +150,6 @@ for metaarea in pac atl; do
 
 			done
 
-			# ----- nam -----
-			gdfn=nam
-			if [ -e ${gdfn} ]; then
-				cat >> cmdfilemar  <<- EOF
-					GDFILE  = ${gdfn}
-					LINE    = 31/2/3/0
-					TITLE   = 31/-3/~ ? ${gdfn} (DASHED) |~${level} DM - ${metaarea}
-					GDATTIM = F${fcsthr}
-					run
-
-					EOF
-				if [ $WrottenZERO -eq 0 ]; then            
-					cat >> cmdfilemar  <<- EOF
-						MAP     = 0
-						LATLON  = 0
-						CLEAR   = no
-
-						EOF
-				fi
-				WrottenZERO=1
-			fi
-
 			# ----- gfs -----
 			gdfn=gfs
 			if [ -e ${gdfn} ]; then
@@ -218,12 +190,6 @@ for metaarea in pac atl; do
 		rm -rf ${fn}
 		if [ -r $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ]; then
 			ln -s $COMINsgfs/gfs.${PDY}/${cyc}/gempak/gfs${sGrid}_${PDY}${cyc}f${fcsthr} ${fn}
-		fi
-
-		fn=nam
-		rm -rf ${fn}
-		if [ -r $COMINnam/nam.${PDY}/gempak/nam_${PDY}${cyc}f${fcsthr} ]; then
-			ln -s $COMINnam/nam.${PDY}/gempak/nam_${PDY}${cyc}f${fcsthr} ${fn}
 		fi
 
 		#export pgm=gdplot2_nc;. prep_step; startmsg
@@ -303,28 +269,6 @@ for metaarea in pac atl; do
 			fi
 
 		done
-
-		# ----- nam -----
-		gdfn=nam
-		if [ -e ${gdfn} ]; then
-			cat >> cmdfilemar_low  <<- EOF
-				GDFILE	= ${gdfn}
-				LINE    = 31/2/3/0
-				HILO    = 31/L#/900-1016/5/50/y
-				TITLE   = 31/-3/~ ? ${gdfn} |~${metaarea} ${metashname}
-				run
-
-				EOF
-			if [ $WrottenZERO -eq 0 ]; then            
-				cat >> cmdfilemar_low  <<- EOF
-					MAP     = 0
-					LATLON  = 0
-					CLEAR   = no
-
-					EOF
-			fi
-			WrottenZERO=1
-		fi
 
 		# ----- gfs -----
 		gdfn=gfs

--- a/jobs/JGEFS_ATMOS_GEMPAK_META
+++ b/jobs/JGEFS_ATMOS_GEMPAK_META
@@ -89,7 +89,6 @@ done
 
 export COMINsgfs=${COMINsgfs:-$(compath.py $envir/com/gfs/${gfs_ver})}
 export COMINecmwf=${COMINecmwf:-$(compath.py $envir/com/ecmwf/${ecmwf_ver})/ecmwf}
-export COMINnam=${COMINnam:-$(compath.py $envir/com/nam/${nam_ver})}
 
 export COMPONENT=${COMPONENT:-atmos}
 if [[ ! -d $COMOUT/$COMPONENT/gempak/meta ]]; then mkdir -p -m 755 $COMOUT/$COMPONENT/gempak/meta; fi

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -3,7 +3,6 @@ export gefs_ver=v12.3.20
 export gfs_ver=v16.3
 export cfs_ver=v2.3
 export ecmwf_ver=v2.1
-export nam_ver=v4.2
 export obsproc_ver=v1.2
 
 export envvar_ver=1.0

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.3.20
+export gefs_ver=v12.3.21
 
 export gfs_ver=v16.3
 export cfs_ver=v2.3


### PR DESCRIPTION
The NAM will be retired when RRFSv1 is implemented. This PR removes NAM products and references from the GEFS workflow. The only GEFS job that uses NAM is `gempak_meta`. NAM references are removed from `gempak_meta`. `nam_ver` and `COMINnam` are also removed. 

This PR will be left in draft until testing is completed. 

Addresses #186 