### PR TITLE
Update gw tag to gefs_v12.3.22-0

### DIFF
--- a/scripts/exgefs_forecast.sh
+++ b/scripts/exgefs_forecast.sh
@@ -137,7 +137,7 @@ if [[ $RERUN = "YES" ]] ; then
 	export restart_hour=$FHMIN
 	export restart_run=.true.    
 	export output_1st_tstep=.true.
-	export stochini=${stochini:-".true."} #true=read in pattern, false=initialize from seed
+	export stochini=${stochini:-".false."} #true=read in pattern, false=initialize from seed
 else
 	export stochini=${stochini:-".false."} #true=read in pattern, false=initialize from seed
 fi

--- a/sorc/checkout.sh
+++ b/sorc/checkout.sh
@@ -15,7 +15,7 @@ if [[ ! -d global-workflow.fd ]] ; then
     rm -f ${logs_dir}/checkout-global-workflow.log
     git clone https://github.com/NOAA-EMC/global-workflow.git global-workflow.fd >>  ${logs_dir}/checkout-global-workflow.log 2>&1
     cd global-workflow.fd
-    git checkout gefs_v12.3.20-0
+    git checkout gefs_v12.3.22-0
     cd sorc
     ./checkout.sh
     ERR=$?

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.3.21
+export gefs_ver=v12.3.22
 
 export gfs_ver=v16.3
 export cfs_ver=v2.3

--- a/versions/run.ver
+++ b/versions/run.ver
@@ -1,4 +1,4 @@
-export gefs_ver=v12.3.20
+export gefs_ver=v12.3.21
 
 export gfs_ver=v16.3
 export cfs_ver=v2.3


### PR DESCRIPTION
This PR updates the global-workflow tag to gefs_v12.3.22-0 to include a helicity bugfix and improvements to model stability. `gefs_ver` is also updated to `v12.3.22`. Furthermore, the stochini changes from v12.3.21 are brought in.  

Addresses #190 